### PR TITLE
fix: map not fully displayed

### DIFF
--- a/webapp/src/app/layouts/RootLayout.tsx
+++ b/webapp/src/app/layouts/RootLayout.tsx
@@ -14,13 +14,13 @@ export const RootLayout: FC = () => {
   }
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-svh">
       <Header
         onLogin={() => navigate("/login")}
         onLogout={() => logout()}
         isAuthenticated={isAuthenticated}
       />
-      <main className="flex flex-1">
+      <main className="flex flex-col flex-1">
         <Outlet />
       </main>
     </div>

--- a/webapp/src/shared/ui/sidebar.tsx
+++ b/webapp/src/shared/ui/sidebar.tsx
@@ -1,12 +1,6 @@
-import { type VariantProps, cva } from "class-variance-authority";
-import { PanelLeft } from "lucide-react";
-import * as React from "react";
-
 import { Slot } from "@radix-ui/react-slot";
-
 import { useIsMobile } from "@shared/hooks/use-mobile";
 import { cn } from "@shared/lib/utils";
-
 import { Button } from "@ui/button";
 import { Input } from "@ui/input";
 import { Separator } from "@ui/separator";
@@ -24,6 +18,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@ui/tooltip";
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeft } from "lucide-react";
+import * as React from "react";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -147,7 +144,7 @@ const SidebarProvider = React.forwardRef<
               ...style,
             }}
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper flex w-full h-full has-[[data-variant=inset]]:bg-sidebar",
               className,
             )}
             ref={ref}

--- a/webapp/src/widgets/map/Map.tsx
+++ b/webapp/src/widgets/map/Map.tsx
@@ -1,9 +1,8 @@
+import { API_URL } from "@shared/api/client";
+import { useLocalStorage } from "@shared/hooks/use-local-storage";
 import { createMap } from "coordo";
 import { type FC, useEffect, useRef, useState } from "react";
-
-import { API_URL } from "@shared/api/client";
 import "./Map.css";
-import { useLocalStorage } from "@shared/hooks/use-local-storage";
 
 const STYLE_URL = `${API_URL}/maps/style.json`;
 
@@ -90,7 +89,7 @@ export const WidgetMap: FC = () => {
   };
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-full">
       <div
         id="map"
         className="w-full h-full"


### PR DESCRIPTION
Issue #58 

- La carte n'était pas affichée entièrement car le composant sidebar utilisait `min-h-svh`  comme classe.
Cela mettait une hauteur min de la taille de l'écran c'est donc pour ça qu'il manquait toujours un bout en bas. Etant donné que d'autres elements sont affichés (notamment le Header), la taille de la sidebar dépasse forcément si elle meme fait la taille de l'ecran !
Idem pour le `h-screen` dans le fichier Map.tsx.
- Je suis passé a la valeur plus moderne `h-svh` pour le RootLayout plutôt que h-screen
Définition svh : https://tailwindcss.com/docs/height#matching-small-viewport (la taille minimum sans tenir compte des elements d'UI de l'appareil)

Le package-lock.json n'était pas à jour