### PR TITLE
fix(map-ref): Move MapProvider around single page

### DIFF
--- a/webapp/src/app/App.tsx
+++ b/webapp/src/app/App.tsx
@@ -1,9 +1,4 @@
-import {
-  ApiProvider,
-  AuthProvider,
-  MapProvider,
-  ThemeProvider,
-} from "./providers";
+import { ApiProvider, AuthProvider, ThemeProvider } from "./providers";
 import { AppRouter } from "./routes/AppRouter";
 import "./styles/globals.css";
 import "./styles/index.css";
@@ -16,9 +11,7 @@ function App() {
     >
       <AuthProvider>
         <ApiProvider>
-          <MapProvider>
-            <AppRouter />
-          </MapProvider>
+          <AppRouter />
         </ApiProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/webapp/src/app/routes/AppRouter.tsx
+++ b/webapp/src/app/routes/AppRouter.tsx
@@ -2,6 +2,7 @@ import { lazy } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import { RootLayout } from "@app/layouts/RootLayout";
+import { MapProvider } from "@app/providers";
 
 import { MainPage } from "@pages/MainPage";
 
@@ -19,7 +20,11 @@ export function AppRouter() {
           path="login"
         />
         <Route
-          element={<RootLayout />}
+          element={
+            <MapProvider>
+              <RootLayout />
+            </MapProvider>
+          }
           path="/"
         >
           <Route


### PR DESCRIPTION
Explanations here: https://github.com/dataforgoodfr/14_Data4Trees/issues/107#issuecomment-4172789451

I tried with option 2 first
- with dependencies => ❌  recreating in loop the map
- with a ref `shouldRecreateMap` to instruct a rebuild of the map when node turns undefined => ❌ the map was displayed correctly again after navigation BUT the listeners to set the popup were not (breaking UI) + it was recreated twice on first load because, IDK why, but the node is unmount then remount... => this seemed to complexify the code and dependencies

I then opt for option 1, considering we litterally have a Single Page Application => the map is used only under one root (the main one), let's just wrap this Route, and not the global router.