### PR TITLE
Chore: Update coordo with pre-release tag

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -22,7 +22,7 @@
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "coordo": "github:dataforgoodfr/Coordonnees#main",
+        "coordo": "github:dataforgoodfr/Coordonnees#0.1.0",
         "i18next": "^25.8.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-http-backend": "^3.0.2",
@@ -3545,7 +3545,7 @@
     },
     "node_modules/coordo": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/dataforgoodfr/Coordonnees.git#7fd1b2d05c8e544942470e4c197a3534ea79a766",
+      "resolved": "git+ssh://git@github.com/dataforgoodfr/Coordonnees.git#eb4badd9dca68bf32a9094ad850970590618e837",
       "license": "ISC",
       "dependencies": {
         "maplibre-gl": "^5.16.0"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -39,7 +39,7 @@
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "coordo": "github:dataforgoodfr/Coordonnees#main",
+    "coordo": "github:dataforgoodfr/Coordonnees#0.1.0",
     "i18next": "^25.8.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-http-backend": "^3.0.2",


### PR DESCRIPTION
Use the pre-release tag "0.1.0" to fix coordo version.