### PR TITLE
Fix(Popup chart): Radar chart not displaying indicator names

### DIFF
--- a/webapp/src/features/charts/components/radar-benef-control.tsx
+++ b/webapp/src/features/charts/components/radar-benef-control.tsx
@@ -46,7 +46,7 @@ export const ChartRadarWithBenefAndControl: FC<
 
   return (
     <Card>
-      <CardHeader className="items-center">
+      <CardHeader className="items-center pb-0">
         <CardDescription>{title}</CardDescription>
       </CardHeader>
       <CardContent className="pb-0">

--- a/webapp/src/features/charts/components/radar-benef-control.tsx
+++ b/webapp/src/features/charts/components/radar-benef-control.tsx
@@ -1,5 +1,11 @@
 import type { FC } from "react";
-import { PolarGrid, PolarRadiusAxis, Radar, RadarChart } from "recharts";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+} from "recharts";
 
 import { useTranslation } from "@shared/i18n";
 
@@ -14,7 +20,7 @@ import {
 } from "@ui/chart";
 
 import { RADAR_CONFIG } from "../constants";
-import { PolarAngleAxisMultiline } from "./polar-angle-axis-multi";
+import { renderPolarAngleTick } from "./render-polar-angle-tick";
 
 type ChartRadarWithBenefAndControlProps = {
   title: string;
@@ -50,7 +56,7 @@ export const ChartRadarWithBenefAndControl: FC<
         >
           <RadarChart
             data={chartData}
-            outerRadius="70%"
+            outerRadius="68%"
           >
             <ChartTooltip
               content={<ChartTooltipContent indicator="line" />}
@@ -60,16 +66,17 @@ export const ChartRadarWithBenefAndControl: FC<
               domain={[0, 10]}
               tickCount={6}
             />
-            <PolarAngleAxisMultiline dataKey="indicator" />
+            <PolarAngleAxis
+              dataKey="indicator"
+              tick={renderPolarAngleTick}
+            />
             <PolarGrid radialLines />
-
             <Radar
               dataKey="benef"
               fill="var(--color-benef)"
               stroke="var(--color-benef)"
               {...RADAR_CONFIG}
             />
-
             {withTemoin && (
               <Radar
                 dataKey="temoin"
@@ -78,13 +85,10 @@ export const ChartRadarWithBenefAndControl: FC<
                 {...RADAR_CONFIG}
               />
             )}
-
-            {withTemoin && (
-              <ChartLegend
-                className="mt-md"
-                content={<ChartLegendContent />}
-              />
-            )}
+            <ChartLegend
+              className="mt-md"
+              content={<ChartLegendContent />}
+            />
           </RadarChart>
         </ChartContainer>
       </CardContent>

--- a/webapp/src/features/charts/components/render-polar-angle-tick.tsx
+++ b/webapp/src/features/charts/components/render-polar-angle-tick.tsx
@@ -1,5 +1,3 @@
-import { PolarAngleAxis } from "recharts";
-
 import { lineBreakLabel } from "../utils";
 
 export const renderPolarAngleTick = ({ payload, x, y, textAnchor }: any) => {
@@ -25,14 +23,5 @@ export const renderPolarAngleTick = ({ payload, x, y, textAnchor }: any) => {
         </tspan>
       ))}
     </text>
-  );
-};
-
-export const PolarAngleAxisMultiline = (props: any) => {
-  return (
-    <PolarAngleAxis
-      tick={renderPolarAngleTick}
-      {...props}
-    />
   );
 };


### PR DESCRIPTION
Before : 
<img width="480" height="480" alt="Capture d’écran du 2026-04-20 22-43-24" src="https://github.com/user-attachments/assets/5c9113f7-a98d-4a96-b9df-f788b0c5bddd" />

This was due to the last commit of PR #129 : moving declaration of component `PolarAngleAxis` in a custom component oustide the chart layout was making the indicator names disappear, and I don't really understand why.

Now I removed the custom component and if works again: 
<img width="480" height="480" alt="Capture d’écran du 2026-04-20 22-42-59" src="https://github.com/user-attachments/assets/92681b64-5635-408a-baed-65a410b128f3" />
