### PR TITLE
feat(popup): Add custom css variants to control popup resizing

### DIFF
--- a/webapp/src/app/styles/globals.css
+++ b/webapp/src/app/styles/globals.css
@@ -40,6 +40,7 @@
 
   /* MapLibre / Coordonnees popup override */
   .maplibregl-popup-content {
+    width: 100%;
     padding: 0 !important;
     overflow: hidden !important;
     color: var(--popover-foreground) !important;

--- a/webapp/src/features/charts/components/bar-chart-benef-control.tsx
+++ b/webapp/src/features/charts/components/bar-chart-benef-control.tsx
@@ -1,4 +1,3 @@
-import { cx } from "class-variance-authority";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { useTranslation } from "@shared/i18n";

--- a/webapp/src/features/charts/components/bar-chart-benef-control.tsx
+++ b/webapp/src/features/charts/components/bar-chart-benef-control.tsx
@@ -1,3 +1,4 @@
+import { cx } from "class-variance-authority";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { useTranslation } from "@shared/i18n";
@@ -24,7 +25,6 @@ export const BarCharWithBenefAndControl: ChartComponentType<BarChartProps> = ({
   chartData,
   legendLabel,
   withTemoin = false,
-  layout = { chartHeight: 80, chartXAxisHeight: 90 },
 }) => {
   const { t } = useTranslation("translations");
   const chartConfig = {
@@ -41,7 +41,8 @@ export const BarCharWithBenefAndControl: ChartComponentType<BarChartProps> = ({
   return (
     <ChartComponent title={title}>
       <ChartContainer
-        className={`mx-auto h-${layout.chartHeight} max-h-${layout.chartHeight} w-full max-w-full`}
+        // Style: Extend the width to the container, but enforce the height for XAxis alignment
+        className="mx-auto h-80 max-h-80 w-full max-w-full"
         config={chartConfig}
       >
         <BarChart
@@ -52,7 +53,7 @@ export const BarCharWithBenefAndControl: ChartComponentType<BarChartProps> = ({
           <XAxis
             axisLine={false}
             dataKey="indicator"
-            height={layout.chartXAxisHeight}
+            height={90}
             interval={0}
             tick={renderXAxisTick}
             tickLine={false}

--- a/webapp/src/features/charts/components/pie-chart-categorical.tsx
+++ b/webapp/src/features/charts/components/pie-chart-categorical.tsx
@@ -44,7 +44,9 @@ export const PieChartCategorical: ChartComponentType<
       title={title}
     >
       <ChartContainer
-        className="mx-auto h-90 w-full max-w-full aspect-auto pb-0 [&_.recharts-pie-label-text]:fill-foreground"
+        // Style - Extend the width to the container, make aspect 5/4 with h auto (due to the legend, width should be superior)
+        // But limit width to 720px to avoid height > 600px (the chard wouldn't fit in the screen)
+        className="mx-auto max-h-full h-auto w-full max-w-180 aspect-5/4 pb-0 [&_.recharts-pie-label-text]:fill-foreground"
         config={chartConfig}
       >
         <PieChart>
@@ -59,7 +61,7 @@ export const PieChartCategorical: ChartComponentType<
             }
             labelLine={false}
             nameKey="name"
-            outerRadius={140}
+            // outerRadius -> Don't specify to adapt to available width
           />
         </PieChart>
       </ChartContainer>

--- a/webapp/src/features/charts/components/radar-benef-control.tsx
+++ b/webapp/src/features/charts/components/radar-benef-control.tsx
@@ -47,7 +47,9 @@ export const ChartRadarWithBenefAndControl: ChartComponentType<
   return (
     <ChartComponent title={title}>
       <ChartContainer
-        className="mx-auto aspect-square max-h-100"
+        // Style - Extend the width to the container, make aspect square with h auto to equal h and w
+        // But limit width to 600px to avoid height > 600px (the chard wouldn't fit in the screen)
+        className="mx-auto aspect-square max-h-full h-auto max-w-150 w-full"
         config={chartConfig}
       >
         <RadarChart

--- a/webapp/src/features/charts/socio-eco/chart-beneficial-practices.tsx
+++ b/webapp/src/features/charts/socio-eco/chart-beneficial-practices.tsx
@@ -54,7 +54,6 @@ export const ChartBeneficialPractices: ChartComponentType<
   return (
     <BarCharWithBenefAndControl
       chartData={chartData}
-      layout={{ chartHeight: 90, chartXAxisHeight: 130 }}
       legendLabel={t(
         "indicators.socioEco.sections.governance.beneficialPractices.legend",
       )}

--- a/webapp/src/features/indicators/seed/seed-indicators.tsx
+++ b/webapp/src/features/indicators/seed/seed-indicators.tsx
@@ -1,7 +1,8 @@
 import { cx } from "class-variance-authority";
-import type { LayerMetadata } from "coordo";
 import { UsersIcon } from "lucide-react";
 import type { FC } from "react";
+
+import type { RenderPopupProps } from "@features/popup/renderPopup";
 
 import { formatDate } from "@shared/lib/utils";
 import { useTranslation } from "@i18n";
@@ -13,17 +14,12 @@ import { IndicatorScrollContainer } from "../components/indicator-scroll-contain
 import type { SeedData } from "./format-data";
 import { useSeedIndicatorElements } from "./use-seed-indicator-elements";
 
-type SeedIndicatorProps = {
-  onClose: () => void;
-  data: SeedData;
-  metadata: LayerMetadata;
-  className?: string;
-};
+type SeedIndicatorProps = RenderPopupProps<SeedData>;
 
 export const SeedIndicator: FC<SeedIndicatorProps> = ({
-  onClose,
   data,
   className,
+  ...headerProps
 }) => {
   const { t } = useTranslation("translations");
 
@@ -37,9 +33,9 @@ export const SeedIndicator: FC<SeedIndicatorProps> = ({
     <div className={cx("flex flex-col", className ?? "")}>
       <IndicatorPopupHeader
         icon={<UsersIcon size={ICON_SIZE_HEADER} />}
-        onCrossClick={onClose}
         subtitle={formatDate(data.date_plantation)}
         title={title}
+        {...headerProps}
       />
 
       <IndicatorScrollContainer>

--- a/webapp/src/features/popup/components/indicator-popup-header.tsx
+++ b/webapp/src/features/popup/components/indicator-popup-header.tsx
@@ -1,4 +1,4 @@
-import { Calendar, XIcon } from "lucide-react";
+import { Calendar, Maximize2Icon, Minimize2Icon, XIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 
 import {
@@ -15,12 +15,38 @@ import {
 } from "@shared/ui/alert";
 import { Button } from "@shared/ui/button";
 
-type IndicatorPopupHeaderProps = {
+export type IndicatorPopupHeaderProps = {
   icon: ReactNode;
   title: string;
   subtitle?: string;
   date?: string;
-  onCrossClick: () => void;
+  onClose: () => void;
+  toggleShiftSize: () => void;
+};
+
+export const AdaptPopupSizeButton = ({
+  toggleShiftSize,
+}: Pick<IndicatorPopupHeaderProps, "toggleShiftSize">) => {
+  return (
+    <Button
+      aria-label="shift-popup-size"
+      className="text-muted-foreground hover:text-info-foreground gap-0"
+      onClick={toggleShiftSize}
+      size="icon"
+      variant="ghost"
+    >
+      <Minimize2Icon
+        size={ICON_SIZE_HEADER}
+        style={{ width: "var(--popup-minimize-size-button-width)" }}
+      />
+      <Maximize2Icon
+        size={ICON_SIZE_HEADER}
+        style={{
+          width: "var(--popup-maximize-size-button-width)",
+        }}
+      />
+    </Button>
+  );
 };
 
 export const IndicatorPopupHeader: FC<IndicatorPopupHeaderProps> = ({
@@ -28,7 +54,8 @@ export const IndicatorPopupHeader: FC<IndicatorPopupHeaderProps> = ({
   title,
   subtitle,
   date,
-  onCrossClick,
+  onClose,
+  toggleShiftSize,
 }) => {
   return (
     <Alert
@@ -59,12 +86,14 @@ export const IndicatorPopupHeader: FC<IndicatorPopupHeaderProps> = ({
         <Button
           aria-label="close-popover"
           className="text-muted-foreground hover:text-info-foreground"
-          onClick={onCrossClick}
+          onClick={onClose}
           size="icon"
           variant="ghost"
         >
           <XIcon size={ICON_SIZE_HEADER} />
         </Button>
+
+        <AdaptPopupSizeButton toggleShiftSize={toggleShiftSize} />
       </AlertAction>
     </Alert>
   );

--- a/webapp/src/features/popup/forest-inventory/popup-forest-inventory.tsx
+++ b/webapp/src/features/popup/forest-inventory/popup-forest-inventory.tsx
@@ -1,5 +1,4 @@
 import { cx } from "class-variance-authority";
-import type { LayerMetadata } from "coordo";
 import { TreesIcon } from "lucide-react";
 import { Activity, type FC, useState } from "react";
 
@@ -14,14 +13,10 @@ import { GridSelector } from "@shared/ui/grid-selector";
 import { useTranslation } from "@i18n";
 
 import { useBiodiversityIndicatorElements } from "../../indicators/biodiversity/use-biodiversity-indicator-elements";
+import type { RenderPopupProps } from "../renderPopup";
 import type { ForestInventoryData } from "./types";
 
-type ForestInventoryPopupContentProps = {
-  onClose: () => void;
-  data: ForestInventoryData;
-  metadata: LayerMetadata;
-  className?: string;
-};
+type ForestInventoryPopupContentProps = RenderPopupProps<ForestInventoryData>;
 
 type TabKind = "biodiversity" | "soil";
 
@@ -32,7 +27,7 @@ const TABS: Record<string, TabKind> = {
 
 export const ForestInventoryPopupContent: FC<
   ForestInventoryPopupContentProps
-> = ({ onClose, data, metadata, className }) => {
+> = ({ data, metadata, className, ...headerProps }) => {
   const { t } = useTranslation("translations");
   const [selectedTab, setSelectedTab] = useState<TabKind>(TABS.BIODIVERSITY);
 
@@ -50,12 +45,12 @@ export const ForestInventoryPopupContent: FC<
       <IndicatorPopupHeader
         date={t("popup.forestInventory.date", { date: formatDate(new Date()) })}
         icon={<TreesIcon size={ICON_SIZE_HEADER} />}
-        onCrossClick={onClose}
         subtitle={
           findCategoricalLabel(metadata, "for", data.for) ||
           t("popup.undefined")
         }
         title={title}
+        {...headerProps}
       />
 
       <GridSelector

--- a/webapp/src/features/popup/renderPopup.tsx
+++ b/webapp/src/features/popup/renderPopup.tsx
@@ -2,32 +2,55 @@ import type { LayerMetadata, PopupOptions } from "coordo";
 import type { FC } from "react";
 import { createRoot } from "react-dom/client";
 
+import type { IndicatorPopupHeaderProps } from "./components/indicator-popup-header";
+
+export const getPopupSizeCustomVariables = (isMaximizedPopupSize: boolean) => {
+  return {
+    "--popup-height": isMaximizedPopupSize ? "100%" : "120",
+    "--popup-max-width": isMaximizedPopupSize ? "100%" : "560px",
+    "--popup-maximize-size-button-width": isMaximizedPopupSize ? 0 : "100%",
+    "--popup-minimize-size-button-width": isMaximizedPopupSize ? "100%" : 0,
+    "--popup-right": isMaximizedPopupSize ? "0" : "auto",
+  } as const;
+};
+
 export const DEFAULT_POPUP_CONFIG: PopupOptions = {
   anchor: "center",
-  className: "rounded-2xl border border-border bg-popover/95 shadow-2xl",
+  // WARNING: Keep a single string for the whole classname, cx is not working
+  className:
+    "z-10 rounded-2xl justify-center border border-border bg-popover/95 shadow-2xl right-[var(--popup-right)] max-h-[99%]",
   closeButton: false,
   closeOnClick: true,
   closeOnMove: false,
-  maxWidth: "560px",
+  maxWidth: "var(--popup-max-width)",
 };
 
-export function getRenderPopupLayer<Properties>(
-  Element: FC<{
-    className: string;
-    data: Properties;
-    onClose: () => void;
-    metadata: LayerMetadata;
-  }>,
-) {
+export type RenderPopupProps<T> = {
+  className: string;
+  data: T;
+  metadata: LayerMetadata;
+} & Pick<IndicatorPopupHeaderProps, "onClose" | "toggleShiftSize">;
+
+export function getRenderPopupLayer<Properties>({
+  Element,
+  toggleShiftSize,
+}: {
+  Element: FC<RenderPopupProps<Properties>>;
+  toggleShiftSize: IndicatorPopupHeaderProps["toggleShiftSize"];
+}) {
   return (properties: Properties, metadata: LayerMetadata) => {
     const container = document.createElement("div");
     const root = createRoot(container);
+
+    container.className = "h-full w-full";
+
     root.render(
       <Element
-        className="w-130 max-w-130 max-h-150"
+        className="h-[var(--popup-height)] max-h-full"
         data={properties}
         metadata={metadata}
         onClose={() => root.unmount()}
+        toggleShiftSize={toggleShiftSize}
       />,
     );
     return container;

--- a/webapp/src/features/popup/renderPopup.tsx
+++ b/webapp/src/features/popup/renderPopup.tsx
@@ -6,7 +6,7 @@ import type { IndicatorPopupHeaderProps } from "./components/indicator-popup-hea
 
 export const getPopupSizeCustomVariables = (isMaximizedPopupSize: boolean) => {
   return {
-    "--popup-height": isMaximizedPopupSize ? "100%" : "120",
+    "--popup-height": isMaximizedPopupSize ? "100%" : "500px",
     "--popup-max-width": isMaximizedPopupSize ? "100%" : "560px",
     "--popup-maximize-size-button-width": isMaximizedPopupSize ? 0 : "100%",
     "--popup-minimize-size-button-width": isMaximizedPopupSize ? "100%" : 0,
@@ -22,7 +22,7 @@ export const DEFAULT_POPUP_CONFIG: PopupOptions = {
   closeButton: false,
   closeOnClick: true,
   closeOnMove: false,
-  maxWidth: "var(--popup-max-width)",
+  maxWidth: "100%", // Make sure it does not overflow
 };
 
 export type RenderPopupProps<T> = {
@@ -42,7 +42,8 @@ export function getRenderPopupLayer<Properties>({
     const container = document.createElement("div");
     const root = createRoot(container);
 
-    container.className = "h-full w-full";
+    // Enforce custom/dynamic max-width at the inner container level
+    container.className = "h-full w-full max-w-[var(--popup-max-width)]";
 
     root.render(
       <Element

--- a/webapp/src/features/popup/socio-eco/popup-socio-eco.tsx
+++ b/webapp/src/features/popup/socio-eco/popup-socio-eco.tsx
@@ -14,14 +14,10 @@ import { findCategoricalLabel, formatDate } from "@shared/lib/utils";
 import { GridSelector } from "@shared/ui/grid-selector";
 import { useTranslation } from "@i18n";
 
+import type { RenderPopupProps } from "../renderPopup";
 import type { SocioEcoData } from "./types";
 
-type SocioEcoIndicatorProps = {
-  onClose: () => void;
-  data: SocioEcoData;
-  metadata: LayerMetadata;
-  className?: string;
-};
+type SocioEcoIndicatorProps = RenderPopupProps<SocioEcoData>;
 
 type TabKind = "resources" | "economy";
 
@@ -46,10 +42,10 @@ const exctractVillageName = (
 };
 
 export const SocioEcoIndicator: FC<SocioEcoIndicatorProps> = ({
-  onClose,
   data,
   metadata,
   className,
+  ...headerProps
 }) => {
   const { t } = useTranslation("translations");
   const [selectedTab, setSelectedTab] = useState<TabKind>(TABS.RESOURCES);
@@ -70,11 +66,11 @@ export const SocioEcoIndicator: FC<SocioEcoIndicatorProps> = ({
       <IndicatorPopupHeader
         date={t("popup.socioEco.date", { date: formatDate(new Date()) })}
         icon={<UsersIcon size={ICON_SIZE_HEADER} />}
-        onCrossClick={onClose}
         subtitle={t("popup.socioEco.subtitleCount", {
           count: data.household_nb,
         })}
         title={title}
+        {...headerProps}
       />
 
       <GridSelector

--- a/webapp/src/pages/dashboard/DashboardPage.tsx
+++ b/webapp/src/pages/dashboard/DashboardPage.tsx
@@ -87,7 +87,13 @@ export function DashboardPage() {
   }
 
   return (
-    <div className="px-7">
+    <div
+      className="px-7 overflow-y-scroll h-full pb-4 custom-scrollbar"
+      style={{
+        "--scrollbar-thumb": "var(--info-foreground)",
+        "--scrollbar-track": "var(--background)",
+      }}
+    >
       <DashboardHeader
         onValueChange={handleYearChange}
         selectedYear={selectedYear}

--- a/webapp/src/widgets/map/Map.tsx
+++ b/webapp/src/widgets/map/Map.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect } from "react";
+import { type FC, useEffect, useState } from "react";
 
 import { type SeedData, SeedIndicator } from "@features/indicators/seed";
 import {
@@ -7,6 +7,7 @@ import {
 } from "@features/popup/forest-inventory";
 import {
   DEFAULT_POPUP_CONFIG,
+  getPopupSizeCustomVariables,
   getRenderPopupLayer,
 } from "@features/popup/renderPopup";
 import {
@@ -38,9 +39,12 @@ const SVG_SIZE = 72;
 
 export const WidgetMap: FC = () => {
   const { isReady, mapApiRef, forests, mapContainerRef } = useMap();
+  const [isMaximizedPopupSize, setIsMaximizedPopupSize] = useState(false);
 
   useEffect(() => {
     if (!isReady || !mapApiRef.current) return;
+
+    const toggleShiftSize = () => setIsMaximizedPopupSize((prev) => !prev);
 
     mapApiRef.current.setLayerSymbol({
       iconSize: getIconSize({ assetSize: SVG_SIZE, targetSize: TARGET_SIZE }),
@@ -58,10 +62,11 @@ export const WidgetMap: FC = () => {
     mapApiRef.current.setLayerPopup<ForestInventoryData>({
       centerOnClick: true,
       layerId: LAYERS.INVENTARY,
-      popupConfig: { ...DEFAULT_POPUP_CONFIG },
-      renderCallback: getRenderPopupLayer<ForestInventoryData>(
-        ForestInventoryPopupContent,
-      ),
+      popupConfig: DEFAULT_POPUP_CONFIG,
+      renderCallback: getRenderPopupLayer<ForestInventoryData>({
+        Element: ForestInventoryPopupContent,
+        toggleShiftSize,
+      }),
       trigger: "click",
     });
 
@@ -69,8 +74,11 @@ export const WidgetMap: FC = () => {
     mapApiRef.current.setLayerPopup<SocioEcoData>({
       centerOnClick: true,
       layerId: LAYERS.ENQUETE,
-      popupConfig: { ...DEFAULT_POPUP_CONFIG },
-      renderCallback: getRenderPopupLayer<SocioEcoData>(SocioEcoIndicator),
+      popupConfig: DEFAULT_POPUP_CONFIG,
+      renderCallback: getRenderPopupLayer<SocioEcoData>({
+        Element: SocioEcoIndicator,
+        toggleShiftSize,
+      }),
       trigger: "click",
     });
 
@@ -78,8 +86,11 @@ export const WidgetMap: FC = () => {
     mapApiRef.current.setLayerPopup<SeedData>({
       centerOnClick: true,
       layerId: LAYERS.SEED,
-      popupConfig: { ...DEFAULT_POPUP_CONFIG },
-      renderCallback: getRenderPopupLayer<SeedData>(SeedIndicator),
+      popupConfig: DEFAULT_POPUP_CONFIG,
+      renderCallback: getRenderPopupLayer<SeedData>({
+        Element: SeedIndicator,
+        toggleShiftSize,
+      }),
       trigger: "click",
     });
   }, [isReady, mapApiRef]);
@@ -99,7 +110,10 @@ export const WidgetMap: FC = () => {
   };
 
   return (
-    <div className="relative w-full h-full">
+    <div
+      className="relative w-full h-full"
+      style={getPopupSizeCustomVariables(isMaximizedPopupSize)}
+    >
       <div
         className="w-full h-full"
         id="map"


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/6c3c4876-a64f-4c4b-942b-0ae8eb81047f

## Goal

Add one button (with 2 icons variants based on the status) to the popup header to toggle a state: whether the popup should take the whole space.

Since we can't inject states inside maplibre renderers, everything needs to be stateless inside the popup rendering. Thus, I go through css variables to inject the right token from the map wrapper.

When not taking the whole space, the height will be the min between 100% and 480 px (h-120)