### PR TITLE
feat:dashboard aggregations

### DIFF
--- a/backend/configs/config.json
+++ b/backend/configs/config.json
@@ -35,7 +35,7 @@
       }
     },
     {
-      "id": "inventaire",
+      "id": "inventaire_for",
       "type": "datapackage",
       "path": "../catalog/inventaire_for",
       "resource": "inv_for",

--- a/backend/configs/config.json
+++ b/backend/configs/config.json
@@ -64,7 +64,7 @@
         "soil_structure_idx": "(thk1*float(not1) + thk2*float(not2) + thk3*float(not3) + thk4*float(not4) + thk5*float(not5)) / (thk1 + thk2 + thk3 + thk4 + thk5) * 2",
         "soil_composition": "count(1)",
         "soil_eros_rainfall_and_wind": "for_weath.concat_ws('-', rain, wind)",
-        "soil_eros_slope": "10 - slop if slop < 10 else 0",
+        "soil_eros_slope": "int(10 - slop if slop < 10 else 0)",
         "soil_eros_cover": "veg",
         "soil_eros_stability": "(int(slak1) + int(slak2) + int(slak3)) / 3",
         "soil_eros_water_infiltration": "600 * 300 / ( (epoch(interval(beer1)) + epoch(interval(beer2)) + epoch(interval(beer3)) + epoch(interval(beer4)) + epoch(interval(beer5)) + epoch(interval(beer6)) + epoch(interval(beer7)) + epoch(interval(beer8)) + epoch(interval(beer9)) + epoch(interval(beer10)) ) / 10 * pi() * 9^2) if beer1 != '' else 0",

--- a/backend/maps/constants.py
+++ b/backend/maps/constants.py
@@ -1,0 +1,51 @@
+# Configuration of Proportion / Average / Total on value or dict of values
+dict_fields_inventaire = {
+    # Biodiversity
+    'biomass_volume': 'average-value',
+    'tree_density': 'average-value',
+    'tree_pop': 'average-value',
+    'richness': 'average-value',
+    'relative_abundance': 'average-dict',
+
+    # Biodiversity - Indirect indicators
+    'epf_tree_density': 'average-value',
+    'epf_deadWood': 'average-value',
+    'epf_tree_diversity': 'average-value',
+    'epf_necromass_pied': 'average-value',
+    'epf_necromass_sol': 'average-value',
+    'epf_spatial_distribution': 'average-value',
+    'epf_diameter_distribution': 'average-value',
+    'epf_vertical_distribution': 'average-value',
+    'epf_dominant_height': 'average-value',
+    'epf_microhabitats': 'average-value',
+
+    # Soil
+    'soil_structure': 'average-value',
+    'soil_composition': 'average-value',
+
+    # Soil erosion
+    'ero_rainfall': 'average-value',
+    'ero_wind': 'average-value',
+    'ero_couv_slope': 'average-value',
+    'ero_couv_cover': 'average-value',
+    'ero_soil_stability': 'average-value',
+    'ero_water_seepage': 'average-value',
+
+    # Soil macrofauna
+    'soil_fauna_density': 'average-value',
+    'soil_fauna_diversity': 'average-value',
+    'soil_fauna_abundance': 'average-dict',
+    'soil_fauna_abundance_tax1': 'average-dict',
+    'soil_fauna_abundance_tax2': 'average-dict',
+    'soil_fauna_abundance_tax3': 'average-dict',
+
+    # Missing density and diversity per taxon
+
+    # Surface macrofauna
+    'surface_fauna_density': 'average-value',
+    'surface_fauna_diversity': 'average-value',
+    'surface_fauna_abundance': 'average-dict',
+    'surface_fauna_abundance_tax1': 'average-dict',
+    'surface_fauna_abundance_tax2': 'average-dict',
+    'surface_fauna_abundance_tax3': 'average-dict',
+}

--- a/backend/maps/constants.py
+++ b/backend/maps/constants.py
@@ -8,44 +8,34 @@ dict_fields_inventaire = {
     'relative_abundance': 'average-dict',
 
     # Biodiversity - Indirect indicators
-    'epf_tree_density': 'average-value',
-    'epf_deadWood': 'average-value',
-    'epf_tree_diversity': 'average-value',
-    'epf_necromass_pied': 'average-value',
-    'epf_necromass_sol': 'average-value',
-    'epf_spatial_distribution': 'average-value',
-    'epf_diameter_distribution': 'average-value',
-    'epf_vertical_distribution': 'average-value',
-    'epf_dominant_height': 'average-value',
-    'epf_microhabitats': 'average-value',
+    'bio_idx_tree_density': 'average-value',
+    'bio_idx_deadWood': 'average-value',
+    'bio_idx_tree_diversity': 'average-value',
+    'bio_idx_spatial_distribution': 'average-value',
+    'bio_idx_diametric_distribution': 'average-value',
+    'bio_idx_vertical_distribution': 'average-value',
+    'bio_idx_dominant_height': 'average-value',
+    'bio_idx_microhabitats': 'average-value',
 
     # Soil
-    'soil_structure': 'average-value',
+    'soil_structure_idx': 'average-value',
     'soil_composition': 'average-value',
 
     # Soil erosion
-    'ero_rainfall': 'average-value',
-    'ero_wind': 'average-value',
-    'ero_couv_slope': 'average-value',
-    'ero_couv_cover': 'average-value',
-    'ero_soil_stability': 'average-value',
-    'ero_water_seepage': 'average-value',
+    'soil_eros_rainfall': 'average-value',
+    'soil_eros_wind': 'average-value',
+    'soil_eros_slope': 'average-value',
+    'soil_eros_cover': 'average-value',
+    'soil_eros_stability': 'average-value',
+    'soil_eros_water_infiltration': 'average-value',
 
     # Soil macrofauna
     'soil_fauna_density': 'average-value',
     'soil_fauna_diversity': 'average-value',
     'soil_fauna_abundance': 'average-dict',
-    'soil_fauna_abundance_tax1': 'average-dict',
-    'soil_fauna_abundance_tax2': 'average-dict',
-    'soil_fauna_abundance_tax3': 'average-dict',
-
-    # Missing density and diversity per taxon
 
     # Surface macrofauna
-    'surface_fauna_density': 'average-value',
-    'surface_fauna_diversity': 'average-value',
-    'surface_fauna_abundance': 'average-dict',
-    'surface_fauna_abundance_tax1': 'average-dict',
-    'surface_fauna_abundance_tax2': 'average-dict',
-    'surface_fauna_abundance_tax3': 'average-dict',
+    'soil_surface_fauna_density': 'average-value',
+    'soil_surface_fauna_diversity': 'average-value',
+    'soil_surface_fauna_abundance': 'average-dict',
 }

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import numpy as np
 
+from . import constants
+
 def mrp_mean(series, weights, population_size):
     """
     Computes means using weights.
@@ -57,58 +59,6 @@ def mrp_mean_dict(series, weights):
 
     return {"value": dict_result, "error": std_error}
 
-# Configuration of Proportion / Average / Total on value or dict of values
-dict_fields_conf = {
-    # Biodiversity
-    'biomass_volume': 'average-value',
-    'tree_density': 'average-value',
-    'tree_pop': 'average-value',
-    'richness': 'average-value',
-    'relative_abundance': 'average-dict',
-
-    # Biodiversity - Indirect indicators
-    'epf_tree_density': 'average-value',
-    'epf_deadWood': 'average-value',
-    'epf_tree_diversity': 'average-value',
-    'epf_necromass_pied': 'average-value',
-    'epf_necromass_sol': 'average-value',
-    'epf_spatial_distribution': 'average-value',
-    'epf_diameter_distribution': 'average-value',
-    'epf_vertical_distribution': 'average-value',
-    'epf_dominant_height': 'average-value',
-    'epf_microhabitats': 'average-value',
-
-    # Soil
-    'soil_structure': 'average-value',
-    'soil_composition': 'average-value',
-
-    # Soil erosion
-    'ero_rainfall': 'average-value',
-    'ero_wind': 'average-value',
-    'ero_couv_slope': 'average-value',
-    'ero_couv_cover': 'average-value',
-    'ero_soil_stability': 'average-value',
-    'ero_water_seepage': 'average-value',
-
-    # Soil macrofauna
-    'soil_fauna_density': 'average-value',
-    'soil_fauna_diversity': 'average-value',
-    'soil_fauna_abundance': 'average-dict',
-    'soil_fauna_abundance_tax1': 'average-dict',
-    'soil_fauna_abundance_tax2': 'average-dict',
-    'soil_fauna_abundance_tax3': 'average-dict',
-
-    # Missing density and diversity per taxon
-
-    # Surface macrofauna
-    'surface_fauna_density': 'average-value',
-    'surface_fauna_diversity': 'average-value',
-    'surface_fauna_abundance': 'average-dict',
-    'surface_fauna_abundance_tax1': 'average-dict',
-    'surface_fauna_abundance_tax2': 'average-dict',
-    'surface_fauna_abundance_tax3': 'average-dict',
-}
-
 def compute_aggregation(data):
 
     df_source = pd.DataFrame([feat.get("properties", {}) for feat in data["features"]])
@@ -146,9 +96,11 @@ def compute_aggregation(data):
     weights_map = df_weights['Mh'].to_dict()
     population_size = df_weights['Mh'].sum()
 
+    dict_fields = constants.dict_fields_inventaire
+
     # Grouping fields by aggregation function
-    list_fields_average_value = [key for key, value in dict_fields_conf.items() if value == 'average-value']
-    list_fields_average_dict = [key for key, value in dict_fields_conf.items() if value == 'average-dict']
+    list_fields_average_value = [key for key, value in dict_fields.items() if value == 'average-value']
+    list_fields_average_dict = [key for key, value in dict_fields.items() if value == 'average-dict']
     list_fields_base = [field for field in df.columns.tolist() if field not in (list_fields_average_value + list_fields_average_dict)]
 
     # Loop on clusters year-sample and applying the related aggregation function

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -26,6 +26,11 @@ def compute_aggregation(data):
     df_source = pd.DataFrame([feat.get("properties", {}) for feat in data["features"]])
     df_source['for'] = df_source['for'].astype(int)
 
+    # WORK AROUND split ero_rainfall_and_wind and ero_couv_slope_and_cover
+    df_source[['ero_rainfall','ero_wind']] = df_source['ero_rainfall_and_wind'].str.split('-', expand=True).astype(int)
+    df_source[['ero_couv_slope','ero_couv_cover']] = df_source['ero_couv_slope_and_cover'].str.split('-', expand=True).astype(int)
+    to_drop = ['ero_rainfall_and_wind','ero_couv_slope_and_cover']
+    df_source.drop(columns=to_drop, inplace=True)
 
     # INVENTAIRE meta data
 

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -1,7 +1,27 @@
+import math
+
 import pandas as pd
 import numpy as np
 
 from . import constants
+
+
+def _to_serializable(value):
+    """Convert numpy/pandas-native values to JSON-serializable Python types."""
+    if isinstance(value, dict):
+        return {_to_serializable(k): _to_serializable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_serializable(v) for v in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+        return str(value)
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    return value
+
 
 def mrp_mean(df, weights_map):
     """
@@ -39,7 +59,7 @@ def mrp_mean(df, weights_map):
     part2 = 1/sample_size**2 * (population_size - sample_size) / (population_size - 1) * (variance_simple - variance_weighted)
     std_error = np.sqrt(part1+part2)
 
-    return {"value": mean_weighted, "error": std_error}
+    return {"value": _to_serializable(mean_weighted), "error": _to_serializable(std_error)}
 
 def mrp_mean_dict(series, weights):
     """
@@ -68,7 +88,7 @@ def mrp_mean_dict(series, weights):
     # TODO
     std_error = np.nan
 
-    return {"value": dict_result, "error": std_error}
+    return {"value": _to_serializable(dict_result), "error": _to_serializable(std_error)}
 
 def compute_aggregation(data):
 
@@ -167,5 +187,4 @@ def compute_aggregation(data):
                 
                 dict_result[project][str(year)][sampling] = result
 
-    print(dict_result)
-    return dict_result
+    return _to_serializable(dict_result['A Kob Ale'])

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -73,38 +73,49 @@ def mrp_mean_dict(series, weights):
 def compute_aggregation(data):
 
     df_source = pd.DataFrame([feat.get("properties", {}) for feat in data["features"]])
-    df_source['for'] = df_source['for'].astype(int)
 
-    # WORK AROUND split ero_rainfall_and_wind and ero_couv_slope_and_cover
-    df_source[['ero_rainfall','ero_wind']] = df_source['ero_rainfall_and_wind'].str.split('-', expand=True).astype(int)
-    df_source[['ero_couv_slope','ero_couv_cover']] = df_source['ero_couv_slope_and_cover'].str.split('-', expand=True).astype(int)
-    to_drop = ['ero_rainfall_and_wind','ero_couv_slope_and_cover']
+    # WORK AROUND change column name, waiting for style.json update
+    df_source = df_source.rename(columns={"for": "loc2"})
+
+    # Data Type
+    df_source['loc2'] = df_source['loc2'].astype(int)
+
+    # WORK AROUND split soil_eros_rainfall_and_wind and typage soil_eros_slope
+    df_source[['soil_eros_rainfall','soil_eros_wind']] = df_source['soil_eros_rainfall_and_wind'].str.split('-', expand=True).astype(int)
+    to_drop = ['soil_eros_rainfall_and_wind']
     df_source.drop(columns=to_drop, inplace=True)
 
     # INVENTAIRE meta data
 
-    # Loading data for clustering (year, beneficiary group/control group, aggregation methods)
-    df_inventaire_meta = pd.read_csv(
-        './catalog/inventaire/inventaire_external.csv',
-        usecols=['index','loc','num','typ','coh','echant']).set_index('index')
-    df_inventaire_meta.rename(columns={"typ": "sample", "loc":"for", "num":"cod", "coh": "year", "echant":"method"}, inplace=True) # BEWARE loc:for and num:cod will be changed in the next data update
+    # Loading projects
+    df_for_samp = pd.read_parquet(
+        './catalog/inventaire_for/for_samp.parquet',
+        columns=['proj','samp','group1','group2','group3','_index'],
+    ).rename(columns={"_index": "index"}).set_index('index')
+
+    # Loading stratums details
+    df_for_pop = pd.read_parquet(
+        './catalog/inventaire_for/for_pop.parquet',
+    ).rename(columns={"_index": "index"}).set_index('index')
+
+    # Loading data for clustering (year, beneficiary group/control group)
+    df_inv_for = pd.read_parquet(
+        './catalog/inventaire_for/inv_for.parquet',
+        columns=['_id','loc1','loc2','ecos','cod','typ','coh','year']
+    ).rename(columns={"_id": "index"}).set_index('index')
+    df_inv_for = df_inv_for.astype('Int64')
 
     # Control group vs Beneficiary group
-    df_inventaire_meta.replace({'Restauration':'beneficiary','Préservation':'beneficiary','Témoin':'control'}, inplace=True)
+    #df_inv_for['typ'] = df_inv_for['typ'].replace({'1':'beneficiary','2':'beneficiary','0':'control'})
+    #df_inv_for.rename(columns={"typ": "sample"}, inplace=True)
 
     # Get clusters to build the result structure
-    df_clusters = df_inventaire_meta[['year','sample','method']].drop_duplicates(keep='first').reset_index(drop=True)
-    df_clusters.sort_values(by=['year','sample'], axis=0)
+    df_clusters = df_inv_for[['year','typ']].drop_duplicates(keep='first').reset_index(drop=True)
+    df_clusters.sort_values(by=['year','typ'], axis=0)
 
     df = df_source.copy()
 
-    # Loading weights from external data
-    # Weights are Mh (for now) /!\ Years are not taken into account
-    df_weights = pd.read_csv(
-        './catalog/inventaire/meteo.csv',
-        usecols=['strat','Mh'],
-        index_col='strat')
-    weights_map = df_weights['Mh'].to_dict()
+    # MAIN Loops
 
     dict_fields = constants.dict_fields_inventaire
 
@@ -117,26 +128,36 @@ def compute_aggregation(data):
     dict_result = {}
     for year in df_clusters['year'].unique():
         dict_result[str(year)] = {}
-        for sampling in ['beneficiary','control']: # also possible to loop on df_clusters['sample'] instead
+        for sampling in df_clusters['typ'].unique():
         
-            # Selecting entries of the current cluster
-            idx = df_inventaire_meta[(df_inventaire_meta['year']==year) & (df_inventaire_meta['sample']==sampling)].set_index(['for','cod']).index
-            df = df_source.copy().set_index(['for','cod'])
+            # Selecting corresponding weights
+            to_select = df_for_pop[
+                (df_for_pop['proj']=='A Kob Ale') &
+                (df_for_pop['year']==year) &
+                (df_for_pop['typ']==sampling)
+                ].index
+            df_weights = df_for_pop.loc[to_select].set_index('loc2')
+            weights_map = df_weights['area'].to_dict()
+            
+            # Selecting entries of the current cluster (with for+cod as unique id)
+            idx = df_inv_for[(df_inv_for['year']==year) & (df_inv_for['typ']==sampling)].set_index(['loc2','cod']).index
+            df = df_source.copy().set_index(['loc2','cod'])
             df = df.loc[idx].reset_index()
             
             # ## INCLUDE HERE a test to select the aggregation function to apply (MRP, etc.)
             # Mapping weights to values to compute MRP mean
-            df["weight"] = df["for"].map(weights_map)
+            df["weight"] = df["loc2"].map(weights_map)
             
             # Computing means and errors on fields with unique values
             df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
             result = {
-                field: mrp_mean(df_case[[field, "for"]], weights_map)
+                field: mrp_mean(df_case[[field, "loc2"]], weights_map)
                 for field in list_fields_average_value
             }
             
             # Computing means and errors on fields with values within dictionnaries
             df_case = df[list_fields_base+list_fields_average_dict+['weight']].copy()
+            display(df_case)
             result = result | {
                 field: mrp_mean_dict(df_case[field], df_case["weight"])
                 for field in list_fields_average_dict

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-def weighted_mean_std(series, weights):
+def mrp_mean(series, weights):
     """
     Computes means using weights.
     Returns the means and the standard errors.
@@ -20,6 +20,86 @@ def weighted_mean_std(series, weights):
 
     return {"value": mean, "error": std_error}
 
+def mrp_mean_dict(series, weights):
+    """
+    Computes means using weights on a serie of dictionnaries.
+    Returns the means and the standard errors.
+    Acts only on lines where both values and weights are defined and contain proper values.
+    """
+    df = pd.concat([series,weights], axis=1)
+    df.rename(columns={df.columns[0]: "dicts", df.columns[1]: "weights" }, inplace = True)
+    df = df.dropna(axis='index', how='any')
+
+    if len(df.index) == 0:
+        return {"value": None, "error": None}
+
+    # Applying weights on each dict
+    df['weighted_dicts'] = df.apply(lambda row: {k: v*row['weights'] for k, v in row['dicts'].items()}, axis=1)
+
+    # Concatenating dicts by sum
+    list_dicts = df['weighted_dicts'].to_list()
+    dict_result = {k: sum(d[k] for d in list_dicts if k in d) for k in set(k for d in list_dicts for k in d)}
+    
+    # Dividing by the sum of weights
+    sum_weights = df['weights'].sum()
+    dict_result = {k: v/sum_weights for k, v in dict_result.items()}
+
+    # TODO
+    std_error = np.nan
+
+    return {"value": dict_result, "error": std_error}
+
+# Configuration of Proportion / Average / Total on value or dict of values
+dict_fields_conf = {
+    # Biodiversity
+    'biomass_volume': 'average-value',
+    'tree_density': 'average-value',
+    'tree_pop': 'average-value',
+    'richness': 'average-value',
+    'relative_abundance': 'average-dict',
+
+    # Biodiversity - Indirect indicators
+    'epf_tree_density': 'average-value',
+    'epf_deadWood': 'average-value',
+    'epf_tree_diversity': 'average-value',
+    'epf_necromass_pied': 'average-value',
+    'epf_necromass_sol': 'average-value',
+    'epf_spatial_distribution': 'average-value',
+    'epf_diameter_distribution': 'average-value',
+    'epf_vertical_distribution': 'average-value',
+    'epf_dominant_height': 'average-value',
+    'epf_microhabitats': 'average-value',
+
+    # Soil
+    'soil_structure': 'average-value',
+    'soil_composition': 'average-value',
+
+    # Soil erosion
+    'ero_rainfall': 'average-value',
+    'ero_wind': 'average-value',
+    'ero_couv_slope': 'average-value',
+    'ero_couv_cover': 'average-value',
+    'ero_soil_stability': 'average-value',
+    'ero_water_seepage': 'average-value',
+
+    # Soil macrofauna
+    'soil_fauna_density': 'average-value',
+    'soil_fauna_diversity': 'average-value',
+    'soil_fauna_abundance': 'average-dict',
+    'soil_fauna_abundance_tax1': 'average-dict',
+    'soil_fauna_abundance_tax2': 'average-dict',
+    'soil_fauna_abundance_tax3': 'average-dict',
+
+    # Missing density and diversity per taxon
+
+    # Surface macrofauna
+    'surface_fauna_density': 'average-value',
+    'surface_fauna_diversity': 'average-value',
+    'surface_fauna_abundance': 'average-dict',
+    'surface_fauna_abundance_tax1': 'average-dict',
+    'surface_fauna_abundance_tax2': 'average-dict',
+    'surface_fauna_abundance_tax3': 'average-dict',
+}
 
 def compute_aggregation(data):
 
@@ -47,9 +127,6 @@ def compute_aggregation(data):
     df_clusters = df_inventaire_meta[['year','sample','method']].drop_duplicates(keep='first').reset_index(drop=True)
     df_clusters.sort_values(by=['year','sample'], axis=0)
 
-    print(df_inventaire_meta)
-    print(df_clusters)
-
     df = df_source.copy()
 
     # Loading weights from external data
@@ -60,25 +137,40 @@ def compute_aggregation(data):
         index_col='strat')
     weights_map = df_weights['Mh'].to_dict()
 
+    # Grouping fields by aggregation function
+    list_fields_average_value = [key for key, value in dict_fields_conf.items() if value == 'average-value']
+    list_fields_average_dict = [key for key, value in dict_fields_conf.items() if value == 'average-dict']
+    list_fields_base = [field for field in df.columns.tolist() if field not in (list_fields_average_value + list_fields_average_dict)]
+
     # Loop on clusters year-sample and applying the related aggregation function
     dict_result = {}
     for year in df_clusters['year'].unique():
         dict_result[str(year)] = {}
         for sampling in ['beneficiary','control']: # also possible to loop on df_clusters['sample'] instead
+        
             # Selecting entries of the current cluster
             idx = df_inventaire_meta[(df_inventaire_meta['year']==year) & (df_inventaire_meta['sample']==sampling)].set_index(['for','cod']).index
             df = df_source.copy().set_index(['for','cod'])
             df = df.loc[idx].reset_index()
+            
             # ## INCLUDE HERE a test to select the aggregation function to apply (MRP, etc.)
             # Mapping weights to values to compute MRP mean
             df["weight"] = df["for"].map(weights_map)
-            # Computing means and errors
-            fields_to_drop = ["for", "cod", "weight"]
-            df_numeric = df.drop(columns=fields_to_drop, errors="ignore").apply(pd.to_numeric, errors="coerce")
+            
+            # Computing means and errors on fields with unique values
+            df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
             result = {
-                col: weighted_mean_std(df_numeric[col], df["weight"])
-                for col in df_numeric.columns
+                field: mrp_mean(df_case[field], df_case["weight"])
+                for field in list_fields_average_value
             }
+            
+            # Computing means and errors on fields with values within dictionnaries
+            df_case = df[list_fields_base+list_fields_average_dict+['weight']].copy()
+            result = result | {
+                field: mrp_mean_dict(df_case[field], df_case["weight"])
+                for field in list_fields_average_dict
+            }
+            
             dict_result[str(year)][sampling] = result
 
     print(dict_result)

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -3,32 +3,43 @@ import numpy as np
 
 from . import constants
 
-def mrp_mean(series, weights, population_size):
+def mrp_mean(df, weights_map):
     """
-    Computes means using weights.
+    Computes cluster means, then weighted means of cluster means.
     Returns the means and the standard errors.
-    Acts only on lines where both values and weights are defined and contain proper values.
+    Acts only on lines where data is defined.
     """
-    mask = series.notna() & weights.notna()
-    x = series[mask].astype(float)
-    w = weights[mask].astype(float)
 
-    sample_size = len(x)
+    df.rename(columns={df.columns[0]: "data", df.columns[1]: "stratum" }, inplace = True)
+    df = df.dropna(axis='index', how='any')
 
-    if sample_size == 0:
+    if len(df.index) == 0:
         return {"value": None, "error": None}
 
-    # Computing the weighted mean
-    mean = np.average(x, weights=w) # equivalent to sum(x * weights) / sum(weights)
+    # Computing aggregates by stratum
+    df_stratums = df.groupby(by='stratum').agg(
+        count=('data','count'),
+        mean=('data','mean'),
+        variance=('data','var'),)
+    df_stratums["weight"] = df_stratums.index.map(weights_map)
+
+    # Sample size and population size (for stratums with data only)
+    sample_size = df_stratums["count"].sum()
+    population_size = df_stratums["weight"].sum()
     
+    # Computing the weighted mean
+    mean_weighted = np.average(df_stratums["mean"], weights=df_stratums["weight"])
+    
+    # Computing the simple variance and the weighted variance
+    variance_simple = df_stratums["variance"].sum()
+    variance_weighted = np.average(df_stratums["variance"], weights=df_stratums["weight"])
+
     # Computing the standard error
-    variance_simple = np.average((x - mean) ** 2)
-    variance_weighted = np.average((x - mean) ** 2, weights=w)
     part1 = 1/sample_size * (1 - sample_size/population_size) * variance_weighted
     part2 = 1/sample_size**2 * (population_size - sample_size) / (population_size - 1) * (variance_simple - variance_weighted)
     std_error = np.sqrt(part1+part2)
 
-    return {"value": mean, "error": std_error}
+    return {"value": mean_weighted, "error": std_error}
 
 def mrp_mean_dict(series, weights):
     """
@@ -121,7 +132,7 @@ def compute_aggregation(data):
             # Computing means and errors on fields with unique values
             df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
             result = {
-                field: mrp_mean(df_case[field], df_case["weight"], population_size)
+                field: mrp_mean(df_case[[field, "for"]], weights_map)
                 for field in list_fields_average_value
             }
             

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -105,7 +105,6 @@ def compute_aggregation(data):
         usecols=['strat','Mh'],
         index_col='strat')
     weights_map = df_weights['Mh'].to_dict()
-    population_size = df_weights['Mh'].sum()
 
     dict_fields = constants.dict_fields_inventaire
 

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -92,6 +92,7 @@ def compute_aggregation(data):
         './catalog/inventaire_for/for_samp.parquet',
         columns=['proj','samp','group1','group2','group3','_index'],
     ).rename(columns={"_index": "index"}).set_index('index')
+    df_for_samp['proj'] = df_for_samp['proj'].str.strip() # because project names may contain unwanted " "
 
     # Loading stratums details
     df_for_pop = pd.read_parquet(
@@ -115,7 +116,7 @@ def compute_aggregation(data):
 
     df = df_source.copy()
 
-    # MAIN Loops
+    # MAIN Loop
 
     dict_fields = constants.dict_fields_inventaire
 
@@ -126,44 +127,45 @@ def compute_aggregation(data):
 
     # Loop on clusters year-sample and applying the related aggregation function
     dict_result = {}
-    for year in df_clusters['year'].unique():
-        dict_result[str(year)] = {}
-        for sampling in df_clusters['typ'].unique():
-        
-            # Selecting corresponding weights
-            to_select = df_for_pop[
-                (df_for_pop['proj']=='A Kob Ale') &
-                (df_for_pop['year']==year) &
-                (df_for_pop['typ']==sampling)
-                ].index
-            df_weights = df_for_pop.loc[to_select].set_index('loc2')
-            weights_map = df_weights['area'].to_dict()
+    for project in df_for_samp['proj'].unique():
+        dict_result[project] = {}
+        for year in df_clusters['year'].unique():
+            dict_result[project][str(year)] = {}
+            for sampling in df_clusters['typ'].unique():
             
-            # Selecting entries of the current cluster (with for+cod as unique id)
-            idx = df_inv_for[(df_inv_for['year']==year) & (df_inv_for['typ']==sampling)].set_index(['loc2','cod']).index
-            df = df_source.copy().set_index(['loc2','cod'])
-            df = df.loc[idx].reset_index()
-            
-            # ## INCLUDE HERE a test to select the aggregation function to apply (MRP, etc.)
-            # Mapping weights to values to compute MRP mean
-            df["weight"] = df["loc2"].map(weights_map)
-            
-            # Computing means and errors on fields with unique values
-            df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
-            result = {
-                field: mrp_mean(df_case[[field, "loc2"]], weights_map)
-                for field in list_fields_average_value
-            }
-            
-            # Computing means and errors on fields with values within dictionnaries
-            df_case = df[list_fields_base+list_fields_average_dict+['weight']].copy()
-            display(df_case)
-            result = result | {
-                field: mrp_mean_dict(df_case[field], df_case["weight"])
-                for field in list_fields_average_dict
-            }
-            
-            dict_result[str(year)][sampling] = result
+                # Selecting corresponding weights
+                to_select = df_for_pop[
+                    (df_for_pop['proj']=='A Kob Ale') &
+                    (df_for_pop['year']==year) &
+                    (df_for_pop['typ']==sampling)
+                    ].index
+                df_weights = df_for_pop.loc[to_select].set_index('loc2')
+                weights_map = df_weights['area'].to_dict()
+                
+                # Selecting entries of the current cluster (with for+cod as unique id)
+                idx = df_inv_for[(df_inv_for['year']==year) & (df_inv_for['typ']==sampling)].set_index(['loc2','cod']).index
+                df = df_source.copy().set_index(['loc2','cod'])
+                df = df.loc[idx].reset_index()
+                
+                # ## INCLUDE HERE a test to select the aggregation function to apply (MRP, etc.)
+                # Mapping weights to values to compute MRP mean
+                df["weight"] = df["loc2"].map(weights_map)
+                
+                # Computing means and errors on fields with unique values
+                df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
+                result = {
+                    field: mrp_mean(df_case[[field, "loc2"]], weights_map)
+                    for field in list_fields_average_value
+                }
+                
+                # Computing means and errors on fields with values within dictionnaries
+                df_case = df[list_fields_base+list_fields_average_dict+['weight']].copy()
+                result = result | {
+                    field: mrp_mean_dict(df_case[field], df_case["weight"])
+                    for field in list_fields_average_dict
+                }
+                
+                dict_result[project][str(year)][sampling] = result
 
     print(dict_result)
     return dict_result

--- a/backend/maps/stats.py
+++ b/backend/maps/stats.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-def mrp_mean(series, weights):
+def mrp_mean(series, weights, population_size):
     """
     Computes means using weights.
     Returns the means and the standard errors.
@@ -11,12 +11,20 @@ def mrp_mean(series, weights):
     x = series[mask].astype(float)
     w = weights[mask].astype(float)
 
-    if len(x) == 0:
+    sample_size = len(x)
+
+    if sample_size == 0:
         return {"value": None, "error": None}
 
+    # Computing the weighted mean
     mean = np.average(x, weights=w) # equivalent to sum(x * weights) / sum(weights)
-    variance = np.average((x - mean) ** 2, weights=w) # still TODO because the formula expected for MRP is much more complex
-    std_error = np.sqrt(variance)
+    
+    # Computing the standard error
+    variance_simple = np.average((x - mean) ** 2)
+    variance_weighted = np.average((x - mean) ** 2, weights=w)
+    part1 = 1/sample_size * (1 - sample_size/population_size) * variance_weighted
+    part2 = 1/sample_size**2 * (population_size - sample_size) / (population_size - 1) * (variance_simple - variance_weighted)
+    std_error = np.sqrt(part1+part2)
 
     return {"value": mean, "error": std_error}
 
@@ -136,6 +144,7 @@ def compute_aggregation(data):
         usecols=['strat','Mh'],
         index_col='strat')
     weights_map = df_weights['Mh'].to_dict()
+    population_size = df_weights['Mh'].sum()
 
     # Grouping fields by aggregation function
     list_fields_average_value = [key for key, value in dict_fields_conf.items() if value == 'average-value']
@@ -160,7 +169,7 @@ def compute_aggregation(data):
             # Computing means and errors on fields with unique values
             df_case = df[list_fields_base+list_fields_average_value+['weight']].copy()
             result = {
-                field: mrp_mean(df_case[field], df_case["weight"])
+                field: mrp_mean(df_case[field], df_case["weight"], population_size)
                 for field in list_fields_average_value
             }
             

--- a/backend/maps/tests.py
+++ b/backend/maps/tests.py
@@ -1,7 +1,6 @@
 import json
 import shutil
 
-import numpy as np
 import pandas as pd
 from django.contrib.auth.models import Permission
 from django.contrib.auth import get_user_model

--- a/backend/maps/tests.py
+++ b/backend/maps/tests.py
@@ -1,11 +1,33 @@
+import json
+import shutil
+
+import numpy as np
+import pandas as pd
 from django.contrib.auth.models import Permission
 from django.contrib.auth import get_user_model
-from django.test import TestCase, Client
+from django.test import TestCase, Client, SimpleTestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
-import shutil 
+
+from maps.stats import mrp_mean
 
 TEST_DIR = 'catalog/test'
+class SerializationTest(SimpleTestCase):
+    def test_mrp_mean_returns_json_serializable_values(self):
+        df = pd.DataFrame(
+            {
+                "value": [1.0, 2.0, 3.0],
+                "stratum": ["a", "b", "a"],
+            }
+        )
+        result = mrp_mean(df, {"a": 1.0, "b": 1.0})
+
+        payload = json.dumps(result)
+
+        self.assertIn('"value"', payload)
+        self.assertIn('"error"', payload)
+
+
 class FileUploadTest(TestCase):
     def setUp(self):
         self.client = Client()

--- a/backend/maps/views.py
+++ b/backend/maps/views.py
@@ -31,7 +31,7 @@ def dashboard_view(request, layer_id):
             layer_id,
             request.body)
 
-    if (layer_id == "inventaire"):
+    if (layer_id == "inventaire_for"):
 
         result = stats.compute_aggregation(data)
 

--- a/webapp/src/shared/api/client.ts
+++ b/webapp/src/shared/api/client.ts
@@ -40,7 +40,6 @@ export const fetchJSONWithAuth = async (
 ) => (await fetchWithAuth(endpoint, options, authToken)).json();
 
 export const createApiClient = (authToken: string | null) => ({
-  // Bases
   getDashboardData: (layerId: string) =>
     fetchJSONWithAuth(`/maps/dashboard/${layerId}`, {}, authToken),
 });

--- a/webapp/src/shared/api/layers.ts
+++ b/webapp/src/shared/api/layers.ts
@@ -1,7 +1,7 @@
 export const LAYERS = {
   BOUNDARIES: "boundaries",
   ENQUETE: "enquete",
-  INVENTARY: "inventaire",
+  INVENTARY: "inventaire_for",
   SATELLITE: "satellite",
   SEED: "seed",
   SEED_POINT: "seed_point",


### PR DESCRIPTION
DONE:
- deal with data series (eg. relative_abundance)
- workaround to split data that is merged into rainfall+wind and couv_slope+cover
- configuration dictionary where is written what function to apply to each field, in new constants.py file
- write the right formula to compute standard errors within the MRP function
- integrate with new datasets
- get the year in external data
- use 'project' as a new root level

STILL IN PROGRESS:
- fix: formula for fields with dicts (first: mean in stratum, then weighted mean of stratum means)
- feat: write other aggregation functions (SRS, SS, etc.)
- feat: write other aggregation functions (total and proportion)
- feat: make generic using settings for stratums detailed in "xxx_samp.parquet" files
- feat: support inventaire_bio and enquete datasets
- refactor: reorganize files
   - keep in stats.py only the functions to compute aggregation
   - put in models.py the objects dealing with data and calling aggregation functions
- fix: remove 'for' field to 'loc2' once updated in style.json
