### PR TITLE
remove baseUrl in tsconfig (deprecation warning) and adapt coordo imports

### DIFF
--- a/webapp/src/features/charts/biodiversity/chart-relative-abundance.tsx
+++ b/webapp/src/features/charts/biodiversity/chart-relative-abundance.tsx
@@ -1,4 +1,4 @@
-import type { LayerMetadata } from "node_modules/coordo/coordo-ts/src/types";
+import type { LayerMetadata } from "coordo";
 
 import { useTranslation } from "@shared/i18n";
 import { findCategoricalLabel, precise } from "@shared/lib/utils";

--- a/webapp/src/features/charts/soil/lib/taxon.ts
+++ b/webapp/src/features/charts/soil/lib/taxon.ts
@@ -1,4 +1,4 @@
-import type { LayerMetadata } from "node_modules/coordo/coordo-ts/src/types";
+import type { LayerMetadata } from "coordo";
 
 import { findCategoricalLabel } from "@shared/lib/utils";
 

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -9,7 +9,6 @@
     }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@app/*": ["./src/app/*"],
       "@pages/*": ["./src/pages/*"],


### PR DESCRIPTION
A detail, see https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259 (shown in a warning in vscode)

I'm still reading the code, and I tried to fix this detail.