### PR TITLE
feat(add-data): Add modal to import data via file upload

### DIFF
--- a/backend/configs/all4trees_config.json
+++ b/backend/configs/all4trees_config.json
@@ -168,7 +168,7 @@
         "revenue_change": "avg(0 - inc_dif if inc_evol = '2' else ifnull(inc_dif, 0))",
         "assets_idx_raw": "avg( ( ( int(hous_typ) + int(hous_size)) * int(hous_own) + ifnull(list_unique(ass),0) + int(lvst_yn) * ( int(lvst_s) + int(lvst_l) ) + ( int( land_own ) + int( land_titl ) + int( land_size ) if int(land_own) > 0 else 0) ) if ( ( int(hous_typ) + int(hous_size)) * int(hous_own) + list_unique(ass) + int(lvst_yn) * ( int(lvst_s) + int(lvst_l) ) + int( land_own ) + int( land_titl ) + int( land_size ) ) <= int(ass_tot_max) )",
         "assets_idx": "10 / int(ass_tot_max) * avg( ( ( int(hous_typ) + int(hous_size)) * int(hous_own) + ifnull(list_unique(ass),0) + int(lvst_yn) * ( int(lvst_s) + int(lvst_l) ) + ( int( land_own ) + int( land_titl ) + int( land_size ) if int(land_own) > 0 else 0) ) if ( ( int(hous_typ) + int(hous_size)) * int(hous_own) + list_unique(ass) + int(lvst_yn) * ( int(lvst_s) + int(lvst_l) ) + int( land_own ) + int( land_titl ) + int( land_size ) ) <= int(ass_tot_max) )",
-        "nb_income_sources" : "avg(int(inc_no))",
+        "nb_income_sources": "avg(int(inc_no))",
         "nb_additional_incomes": "'N/A'",
         "benef_pract1": "count(1 if int(pract1) = 2) / count(1) * 100",
         "benef_pract2": "count(1 if int(pract2) = 2) / count(1) * 100",

--- a/backend/maps/datapackage_manager.py
+++ b/backend/maps/datapackage_manager.py
@@ -96,7 +96,7 @@ class DatapackageManager:
         try:
             params = self.parse_params(loader_method)
         except ValueError as e:
-            return ParseError(e)
+            raise ParseError(e)
 
         # getting keys to get in self.request.FILES
         file_keys = ["data"]

--- a/backend/maps/views.py
+++ b/backend/maps/views.py
@@ -109,7 +109,7 @@ def remove_foreign_key_view(request):
 def get_map(user):
     user_map = copy(map)
     filter = ''
-    if user.is_authenticated:
+    if user.is_authenticated and bool(user.project):
         project = user.project
         if (project.lower() != ADMIN_PROJECT):
             filter = f"proj = '{project}' or conf = 1"

--- a/webapp/src/app/routes/app-router-all4trees.tsx
+++ b/webapp/src/app/routes/app-router-all4trees.tsx
@@ -2,12 +2,17 @@ import { lazy } from "react";
 
 import { MapProviderAll4Trees } from "@app/providers/map-provider-all4trees";
 
+import { LAYERS } from "@shared/api/layers";
+import { useTranslation } from "@shared/i18n";
+
 import { AppRouterBase } from "./app-router-base";
 
 const MainPage = lazy(() => import("@pages/all4trees/main"));
 const DashboardPage = lazy(() => import("@pages/all4trees/dashboard"));
 
 export const AppRouterAll4Trees = () => {
+  const { t } = useTranslation("all4trees");
+
   return (
     <AppRouterBase
       DashboardPage={DashboardPage}
@@ -15,6 +20,16 @@ export const AppRouterAll4Trees = () => {
       MapProvider={MapProviderAll4Trees}
       rootLayoutProps={{
         hasDashboard: true,
+        layerOptions: [
+          {
+            translation: t("filters.categories.actions.forestInventary"),
+            value: LAYERS.INVENTARY,
+          },
+          {
+            translation: t("filters.categories.actions.socioEco"),
+            value: LAYERS.ENQUETE,
+          },
+        ],
         logoSrc: "/logo_all4trees.png",
       }}
     />

--- a/webapp/src/app/routes/app-router-all4trees.tsx
+++ b/webapp/src/app/routes/app-router-all4trees.tsx
@@ -22,8 +22,12 @@ export const AppRouterAll4Trees = () => {
         hasDashboard: true,
         layerOptions: [
           {
-            translation: t("filters.categories.actions.forestInventary"),
-            value: LAYERS.INVENTARY,
+            translation: t("filters.categories.actions.forestInventory"),
+            value: LAYERS.INVENTORY_FOR,
+          },
+          {
+            translation: t("filters.categories.actions.treeDiversity"),
+            value: LAYERS.INVENTORY_BIO,
           },
           {
             translation: t("filters.categories.actions.socioEco"),

--- a/webapp/src/app/styles/all4trees.css
+++ b/webapp/src/app/styles/all4trees.css
@@ -91,6 +91,8 @@
   --destructive: #dc2626;
   --info: var(--custom-color-blue-light);
   --info-foreground: var(--custom-color-blue-dark);
+  --success: rgb(237, 247, 237);
+  --success-foreground: #2e7d32;
 
   --border: rgba(0, 0, 0, 0.15);
   --input: #ffffff;
@@ -135,6 +137,8 @@
   --destructive: #ef4444;
   --info: var(--custom-color-blue-dark);
   --info-foreground: var(--custom-color-blue-light);
+  --success: rgb(12, 19, 13);
+  --success-foreground: #66bb6a;
 
   --border: rgba(255, 255, 255, 0.15);
   --input: rgba(255, 255, 255, 0.05);

--- a/webapp/src/app/styles/index.css
+++ b/webapp/src/app/styles/index.css
@@ -58,6 +58,8 @@
   --color-destructive: var(--destructive);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
 
   --color-border: var(--border);
   --color-input: var(--input);

--- a/webapp/src/features/add-data/add-data-dialog.tsx
+++ b/webapp/src/features/add-data/add-data-dialog.tsx
@@ -25,8 +25,7 @@ import {
 } from "@ui/select";
 
 import {
-  ACCEPTED_EXTENSIONS,
-  isCsvFileName,
+  ACCEPTED_EXTENSIONS_BY_KIND,
   RESOURCE_KINDS,
   type ResourceKind,
 } from "./constants";
@@ -49,24 +48,18 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
   const { t } = useTranslation("common");
   const {
     error,
-    file,
     form,
     isLoading,
     isSuccess,
     kind,
     reset,
-    resource,
     setFile,
     setForm,
     setKind,
-    setResource,
     submit,
   } = useAddData();
 
-  // A single resource name only makes sense for CSV uploads. Excel/zip files
-  // can populate several resources, whose names coordo infers from the sheet
-  // (or inner file) names, so we hide the field and warn the user instead.
-  const isCsv = file ? isCsvFileName(file.name) : true;
+  const isFormData = kind === RESOURCE_KINDS.FormData;
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -118,16 +111,6 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
           </div>
 
           <div className="grid gap-3">
-            <Label htmlFor="add-data-file">{t("addData.field.file")}</Label>
-            <Input
-              accept={ACCEPTED_EXTENSIONS}
-              id="add-data-file"
-              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-              type="file"
-            />
-          </div>
-
-          <div className="grid gap-3">
             <Label>{t("addData.field.kind")}</Label>
             <RadioGroup
               className="flex gap-6"
@@ -161,41 +144,37 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
             </RadioGroup>
           </div>
 
-          {isCsv ? (
-            <div className="grid gap-3">
-              <Label htmlFor="add-data-resource">
-                {t("addData.field.resource")}
-              </Label>
-              <Input
-                id="add-data-resource"
-                onChange={(event) => setResource(event.target.value)}
-                placeholder={t("addData.field.resourcePlaceholder")}
-                value={resource}
-              />
-              <p className="text-sm text-muted-foreground">
-                {t("addData.resourceHint.csv")}
-              </p>
-            </div>
-          ) : (
-            <Alert>
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                {t("addData.resourceHint.excel")}
-              </AlertDescription>
-            </Alert>
-          )}
+          <div className="grid gap-3">
+            <Label htmlFor="add-data-file">{t("addData.field.file")}</Label>
+            <Input
+              accept={ACCEPTED_EXTENSIONS_BY_KIND[kind]}
+              className="hover:cursor-pointer"
+              id="add-data-file"
+              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              type="file"
+            />
+            <p className="text-sm text-muted-foreground">
+              {isFormData
+                ? t("addData.hint.formData")
+                : t("addData.hint.externalData")}
+            </p>
+          </div>
 
           {error && (
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
-              <AlertDescription>{t(`addData.error.${error}`)}</AlertDescription>
+              <AlertDescription style={{ "--tw-translate-y": 0 }}>
+                {t(`addData.error.${error}`)}
+              </AlertDescription>
             </Alert>
           )}
 
           {isSuccess && (
             <Alert>
               <CheckCircle2 className="h-4 w-4" />
-              <AlertDescription>{t("addData.success")}</AlertDescription>
+              <AlertDescription style={{ "--tw-translate-y": 0 }}>
+                {t("addData.success")}
+              </AlertDescription>
             </Alert>
           )}
 

--- a/webapp/src/features/add-data/add-data-dialog.tsx
+++ b/webapp/src/features/add-data/add-data-dialog.tsx
@@ -1,0 +1,214 @@
+import { AlertCircle, CheckCircle2, UploadIcon } from "lucide-react";
+import type { FC } from "react";
+
+import { useTranslation } from "@i18n";
+
+import { Alert, AlertDescription } from "@ui/alert";
+import { Button } from "@ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@ui/dialog";
+import { Input } from "@ui/input";
+import { Label } from "@ui/label";
+import { RadioGroup, RadioGroupItem } from "@ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@ui/select";
+
+import {
+  ACCEPTED_EXTENSIONS,
+  ADD_DATA_FORMS,
+  type AddDataForm,
+  isCsvFileName,
+  RESOURCE_KINDS,
+  type ResourceKind,
+} from "./constants";
+import { useAddData } from "./use-add-data";
+
+interface AddDataDialogProps {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export const AddDataDialog: FC<AddDataDialogProps> = ({
+  onOpenChange,
+  open,
+}) => {
+  const { t } = useTranslation("common");
+  const {
+    error,
+    file,
+    form,
+    isLoading,
+    isSuccess,
+    kind,
+    reset,
+    resource,
+    setFile,
+    setForm,
+    setKind,
+    setResource,
+    submit,
+  } = useAddData();
+
+  // A single resource name only makes sense for CSV uploads. Excel/zip files
+  // can populate several resources, whose names coordo infers from the sheet
+  // (or inner file) names, so we hide the field and warn the user instead.
+  const isCsv = file ? isCsvFileName(file.name) : true;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      reset();
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    submit();
+  };
+
+  return (
+    <Dialog
+      onOpenChange={handleOpenChange}
+      open={open}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("addData.title")}</DialogTitle>
+          <DialogDescription>{t("addData.description")}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex flex-col gap-6"
+          onSubmit={handleSubmit}
+        >
+          <div className="grid gap-3">
+            <Label htmlFor="add-data-form">{t("addData.field.form")}</Label>
+            <Select
+              onValueChange={(value) => setForm(value as AddDataForm)}
+              value={form}
+            >
+              <SelectTrigger id="add-data-form">
+                <SelectValue placeholder={t("addData.field.formPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {ADD_DATA_FORMS.map((formName) => (
+                  <SelectItem
+                    key={formName}
+                    value={formName}
+                  >
+                    {t(`addData.forms.${formName}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-3">
+            <Label htmlFor="add-data-file">{t("addData.field.file")}</Label>
+            <Input
+              accept={ACCEPTED_EXTENSIONS}
+              id="add-data-file"
+              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              type="file"
+            />
+          </div>
+
+          <div className="grid gap-3">
+            <Label>{t("addData.field.kind")}</Label>
+            <RadioGroup
+              className="flex gap-6"
+              onValueChange={(value) => setKind(value as ResourceKind)}
+              value={kind}
+            >
+              <div className="flex items-center gap-3">
+                <RadioGroupItem
+                  id="add-data-kind-form"
+                  value={RESOURCE_KINDS.FormData}
+                />
+                <Label
+                  className="font-normal"
+                  htmlFor="add-data-kind-form"
+                >
+                  {t("addData.kind.formData")}
+                </Label>
+              </div>
+              <div className="flex items-center gap-3">
+                <RadioGroupItem
+                  id="add-data-kind-external"
+                  value={RESOURCE_KINDS.ExternalData}
+                />
+                <Label
+                  className="font-normal"
+                  htmlFor="add-data-kind-external"
+                >
+                  {t("addData.kind.externalData")}
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {isCsv ? (
+            <div className="grid gap-3">
+              <Label htmlFor="add-data-resource">
+                {t("addData.field.resource")}
+              </Label>
+              <Input
+                id="add-data-resource"
+                onChange={(event) => setResource(event.target.value)}
+                placeholder={t("addData.field.resourcePlaceholder")}
+                value={resource}
+              />
+              <p className="text-sm text-muted-foreground">
+                {t("addData.resourceHint.csv")}
+              </p>
+            </div>
+          ) : (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {t("addData.resourceHint.excel")}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{t(`addData.error.${error}`)}</AlertDescription>
+            </Alert>
+          )}
+
+          {isSuccess && (
+            <Alert>
+              <CheckCircle2 className="h-4 w-4" />
+              <AlertDescription>{t("addData.success")}</AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button
+              disabled={isLoading}
+              type="submit"
+            >
+              <UploadIcon />
+              {isLoading
+                ? t("addData.button.pending")
+                : t("addData.button.submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/webapp/src/features/add-data/add-data-dialog.tsx
+++ b/webapp/src/features/add-data/add-data-dialog.tsx
@@ -26,20 +26,23 @@ import {
 
 import {
   ACCEPTED_EXTENSIONS,
-  ADD_DATA_FORMS,
-  type AddDataForm,
   isCsvFileName,
   RESOURCE_KINDS,
   type ResourceKind,
 } from "./constants";
 import { useAddData } from "./use-add-data";
 
-interface AddDataDialogProps {
+// The value is the catalog folder name
+export type LayerOptions = Array<{ value: string; translation: string }>;
+
+type AddDataDialogProps = {
+  layerOptions: LayerOptions;
   onOpenChange: (open: boolean) => void;
   open: boolean;
-}
+};
 
 export const AddDataDialog: FC<AddDataDialogProps> = ({
+  layerOptions,
   onOpenChange,
   open,
 }) => {
@@ -95,19 +98,19 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
           <div className="grid gap-3">
             <Label htmlFor="add-data-form">{t("addData.field.form")}</Label>
             <Select
-              onValueChange={(value) => setForm(value as AddDataForm)}
+              onValueChange={(value) => setForm(value)}
               value={form}
             >
               <SelectTrigger id="add-data-form">
                 <SelectValue placeholder={t("addData.field.formPlaceholder")} />
               </SelectTrigger>
               <SelectContent>
-                {ADD_DATA_FORMS.map((formName) => (
+                {layerOptions.map(({ value, translation }) => (
                   <SelectItem
-                    key={formName}
-                    value={formName}
+                    key={value}
+                    value={value}
                   >
-                    {t(`addData.forms.${formName}`)}
+                    {translation}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/webapp/src/features/add-data/add-data-dialog.tsx
+++ b/webapp/src/features/add-data/add-data-dialog.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 
 import { useTranslation } from "@i18n";
 
-import { Alert, AlertDescription } from "@ui/alert";
+import { Alert, AlertAction, AlertDescription } from "@ui/alert";
 import { Button } from "@ui/button";
 import {
   Dialog,
@@ -147,7 +147,7 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
           <div className="grid gap-3">
             <Label htmlFor="add-data-file">{t("addData.field.file")}</Label>
             <Input
-              accept={ACCEPTED_EXTENSIONS_BY_KIND[kind]}
+              accept={ACCEPTED_EXTENSIONS_BY_KIND[kind].join(",")}
               className="hover:cursor-pointer"
               id="add-data-file"
               onChange={(event) => setFile(event.target.files?.[0] ?? null)}
@@ -170,11 +170,20 @@ export const AddDataDialog: FC<AddDataDialogProps> = ({
           )}
 
           {isSuccess && (
-            <Alert>
+            <Alert variant="success">
               <CheckCircle2 className="h-4 w-4" />
               <AlertDescription style={{ "--tw-translate-y": 0 }}>
                 {t("addData.success")}
               </AlertDescription>
+              <AlertAction>
+                <Button
+                  onClick={() => window.location.reload()}
+                  size="sm"
+                  variant="default"
+                >
+                  {t("addData.refreshData")}
+                </Button>
+              </AlertAction>
             </Alert>
           )}
 

--- a/webapp/src/features/add-data/constants.ts
+++ b/webapp/src/features/add-data/constants.ts
@@ -6,8 +6,15 @@ export const RESOURCE_KINDS = {
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[keyof typeof RESOURCE_KINDS];
 
-// Extensions accepted by coordo's file loaders.
-export const ACCEPTED_EXTENSIONS = ".csv,.xls,.xlsx,.zip";
+// coordo loader the backend selects, per resource kind. cf LoaderType
+export const RESOURCE_TYPE_BY_KIND = {
+  [RESOURCE_KINDS.ExternalData]: "file",
+  [RESOURCE_KINDS.FormData]: "kobotoolbox",
+} as const;
 
-export const isCsvFileName = (fileName: string): boolean =>
-  fileName.toLowerCase().endsWith(".csv");
+// Accepted upload extensions per kind (coordo's file / kobotoolbox loaders).
+// Form data is the multi-sheet KoboToolbox answers workbook (.xlsx).
+export const ACCEPTED_EXTENSIONS_BY_KIND = {
+  [RESOURCE_KINDS.ExternalData]: ".csv,.xls,.xlsx",
+  [RESOURCE_KINDS.FormData]: ".xlsx",
+} as const;

--- a/webapp/src/features/add-data/constants.ts
+++ b/webapp/src/features/add-data/constants.ts
@@ -1,0 +1,24 @@
+// Datapackage folders (under backend `catalog/`) a user can push new data into.
+// The value is the catalog folder name, also used as the datapackage `form`.
+export const ADD_DATA_FORMS = [
+  "inventaire_for",
+  "inventaire_bio",
+  "enquete",
+  "seed",
+] as const;
+
+export type AddDataForm = (typeof ADD_DATA_FORMS)[number];
+
+// Kind of resource the uploaded file represents.
+export const RESOURCE_KINDS = {
+  ExternalData: "external_data",
+  FormData: "form_data",
+} as const;
+
+export type ResourceKind = (typeof RESOURCE_KINDS)[keyof typeof RESOURCE_KINDS];
+
+// Extensions accepted by coordo's file loaders.
+export const ACCEPTED_EXTENSIONS = ".csv,.xls,.xlsx,.zip";
+
+export const isCsvFileName = (fileName: string): boolean =>
+  fileName.toLowerCase().endsWith(".csv");

--- a/webapp/src/features/add-data/constants.ts
+++ b/webapp/src/features/add-data/constants.ts
@@ -1,14 +1,3 @@
-// Datapackage folders (under backend `catalog/`) a user can push new data into.
-// The value is the catalog folder name, also used as the datapackage `form`.
-export const ADD_DATA_FORMS = [
-  "inventaire_for",
-  "inventaire_bio",
-  "enquete",
-  "seed",
-] as const;
-
-export type AddDataForm = (typeof ADD_DATA_FORMS)[number];
-
 // Kind of resource the uploaded file represents.
 export const RESOURCE_KINDS = {
   ExternalData: "external_data",

--- a/webapp/src/features/add-data/constants.ts
+++ b/webapp/src/features/add-data/constants.ts
@@ -15,6 +15,17 @@ export const RESOURCE_TYPE_BY_KIND = {
 // Accepted upload extensions per kind (coordo's file / kobotoolbox loaders).
 // Form data is the multi-sheet KoboToolbox answers workbook (.xlsx).
 export const ACCEPTED_EXTENSIONS_BY_KIND = {
-  [RESOURCE_KINDS.ExternalData]: ".csv,.xls,.xlsx",
-  [RESOURCE_KINDS.FormData]: ".xlsx",
+  [RESOURCE_KINDS.ExternalData]: [
+    ".csv",
+    ".tsv",
+    ".tab",
+    ".xlsx",
+    ".xls",
+    ".xlsm",
+    ".xlsb",
+    ".odf",
+    ".ods",
+    ".odt",
+  ],
+  [RESOURCE_KINDS.FormData]: [".csv", ".xlsx"],
 } as const;

--- a/webapp/src/features/add-data/index.ts
+++ b/webapp/src/features/add-data/index.ts
@@ -1,1 +1,1 @@
-export { AddDataDialog } from "./add-data-dialog";
+export { AddDataDialog, type LayerOptions } from "./add-data-dialog";

--- a/webapp/src/features/add-data/index.ts
+++ b/webapp/src/features/add-data/index.ts
@@ -1,0 +1,1 @@
+export { AddDataDialog } from "./add-data-dialog";

--- a/webapp/src/features/add-data/use-add-data.ts
+++ b/webapp/src/features/add-data/use-add-data.ts
@@ -2,18 +2,14 @@ import { useState } from "react";
 
 import { useApi } from "@shared/hooks/useApi";
 
-import {
-  type AddDataForm,
-  RESOURCE_KINDS,
-  type ResourceKind,
-} from "./constants";
+import { RESOURCE_KINDS, type ResourceKind } from "./constants";
 
 type AddDataError = "generic" | "missingFile" | "missingForm";
 
 export const useAddData = () => {
   const api = useApi();
 
-  const [form, setForm] = useState<AddDataForm | "">("");
+  const [form, setForm] = useState<string>("");
   const [file, setFile] = useState<File | null>(null);
   const [kind, setKind] = useState<ResourceKind>(RESOURCE_KINDS.FormData);
   const [resource, setResource] = useState("");

--- a/webapp/src/features/add-data/use-add-data.ts
+++ b/webapp/src/features/add-data/use-add-data.ts
@@ -2,7 +2,11 @@ import { useState } from "react";
 
 import { useApi } from "@shared/hooks/useApi";
 
-import { RESOURCE_KINDS, type ResourceKind } from "./constants";
+import {
+  RESOURCE_KINDS,
+  RESOURCE_TYPE_BY_KIND,
+  type ResourceKind,
+} from "./constants";
 
 type AddDataError = "generic" | "missingFile" | "missingForm";
 
@@ -12,7 +16,6 @@ export const useAddData = () => {
   const [form, setForm] = useState<string>("");
   const [file, setFile] = useState<File | null>(null);
   const [kind, setKind] = useState<ResourceKind>(RESOURCE_KINDS.FormData);
-  const [resource, setResource] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState<AddDataError | null>(null);
@@ -23,7 +26,6 @@ export const useAddData = () => {
     setForm("");
     setIsSuccess(false);
     setKind(RESOURCE_KINDS.FormData);
-    setResource("");
   };
 
   const submit = async () => {
@@ -41,26 +43,14 @@ export const useAddData = () => {
 
     setIsLoading(true);
 
-    // Field names are centralized here so they can be aligned with the
-    // reworked add-data endpoint in a single place.
     const formData = new FormData();
-    formData.append("action", "add");
-    formData.append("file", file);
-    formData.append("form", form);
-    formData.append("kind", kind);
+    formData.append("resource_type", RESOURCE_TYPE_BY_KIND[kind]);
     formData.append("package", `catalog/${form}`);
-
-    // Optional: coordo infers the resource name from the file/sheet names
-    // when it is omitted.
-    const trimmedResource = resource.trim();
-    if (trimmedResource) {
-      formData.append("resource", trimmedResource);
-    }
+    formData.append("data", file);
 
     try {
-      await api.addData(formData);
+      await api.appendData(formData);
       setFile(null);
-      setResource("");
       setIsSuccess(true);
     } catch {
       setError("generic");
@@ -77,11 +67,9 @@ export const useAddData = () => {
     isSuccess,
     kind,
     reset,
-    resource,
     setFile,
     setForm,
     setKind,
-    setResource,
     submit,
   };
 };

--- a/webapp/src/features/add-data/use-add-data.ts
+++ b/webapp/src/features/add-data/use-add-data.ts
@@ -1,0 +1,91 @@
+import { useState } from "react";
+
+import { useApi } from "@shared/hooks/useApi";
+
+import {
+  type AddDataForm,
+  RESOURCE_KINDS,
+  type ResourceKind,
+} from "./constants";
+
+type AddDataError = "generic" | "missingFile" | "missingForm";
+
+export const useAddData = () => {
+  const api = useApi();
+
+  const [form, setForm] = useState<AddDataForm | "">("");
+  const [file, setFile] = useState<File | null>(null);
+  const [kind, setKind] = useState<ResourceKind>(RESOURCE_KINDS.FormData);
+  const [resource, setResource] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [error, setError] = useState<AddDataError | null>(null);
+
+  const reset = () => {
+    setError(null);
+    setFile(null);
+    setForm("");
+    setIsSuccess(false);
+    setKind(RESOURCE_KINDS.FormData);
+    setResource("");
+  };
+
+  const submit = async () => {
+    setError(null);
+    setIsSuccess(false);
+
+    if (!form) {
+      setError("missingForm");
+      return;
+    }
+    if (!file) {
+      setError("missingFile");
+      return;
+    }
+
+    setIsLoading(true);
+
+    // Field names are centralized here so they can be aligned with the
+    // reworked add-data endpoint in a single place.
+    const formData = new FormData();
+    formData.append("action", "add");
+    formData.append("file", file);
+    formData.append("form", form);
+    formData.append("kind", kind);
+    formData.append("package", `catalog/${form}`);
+
+    // Optional: coordo infers the resource name from the file/sheet names
+    // when it is omitted.
+    const trimmedResource = resource.trim();
+    if (trimmedResource) {
+      formData.append("resource", trimmedResource);
+    }
+
+    try {
+      await api.addData(formData);
+      setFile(null);
+      setResource("");
+      setIsSuccess(true);
+    } catch {
+      setError("generic");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    error,
+    file,
+    form,
+    isLoading,
+    isSuccess,
+    kind,
+    reset,
+    resource,
+    setFile,
+    setForm,
+    setKind,
+    setResource,
+    submit,
+  };
+};

--- a/webapp/src/features/add-data/use-add-data.ts
+++ b/webapp/src/features/add-data/use-add-data.ts
@@ -51,6 +51,7 @@ export const useAddData = () => {
     try {
       await api.appendData(formData);
       setFile(null);
+      setForm("");
       setIsSuccess(true);
     } catch {
       setError("generic");

--- a/webapp/src/shared/api/client.ts
+++ b/webapp/src/shared/api/client.ts
@@ -43,6 +43,12 @@ export const fetchJSONWithAuth = async (
 ) => (await fetchWithAuth(endpoint, options, authToken)).json();
 
 export const createApiClient = (authToken: string | null) => ({
+  addData: (formData: FormData) =>
+    fetchWithAuth(
+      `/maps/add-data/`,
+      { body: formData, method: "POST" },
+      authToken,
+    ),
   getCatalogResource: (layerId: string, resourceName: string) =>
     fetchJSONWithAuth(`/catalog/${layerId}/${resourceName}`, {}, authToken),
   getCatalogResourceList: (layerId: string, resourceList: string[]) =>

--- a/webapp/src/shared/api/client.ts
+++ b/webapp/src/shared/api/client.ts
@@ -43,9 +43,9 @@ export const fetchJSONWithAuth = async (
 ) => (await fetchWithAuth(endpoint, options, authToken)).json();
 
 export const createApiClient = (authToken: string | null) => ({
-  addData: (formData: FormData) =>
+  appendData: (formData: FormData) =>
     fetchWithAuth(
-      `/maps/add-data/`,
+      `/maps/append-data/`,
       { body: formData, method: "POST" },
       authToken,
     ),

--- a/webapp/src/shared/i18n/translations/en/common.json
+++ b/webapp/src/shared/i18n/translations/en/common.json
@@ -18,12 +18,6 @@
       "resource": "Resource name (optional)",
       "resourcePlaceholder": "Leave empty to infer from file name"
     },
-    "forms": {
-      "enquete": "Household survey",
-      "inventaire_bio": "Biological inventory",
-      "inventaire_for": "Forest inventory",
-      "seed": "Reforestation"
-    },
     "kind": {
       "externalData": "External data",
       "formData": "Form data"

--- a/webapp/src/shared/i18n/translations/en/common.json
+++ b/webapp/src/shared/i18n/translations/en/common.json
@@ -14,17 +14,15 @@
       "file": "File to upload",
       "form": "Layer / Form to update",
       "formPlaceholder": "Select a layer",
-      "kind": "Kind of resource",
-      "resource": "Resource name (optional)",
-      "resourcePlaceholder": "Leave empty to infer from file name"
+      "kind": "Kind of resource"
+    },
+    "hint": {
+      "externalData": "The file name must match the target resource (e.g. \"for_dw.csv\"); Excel sheets are matched by sheet name.",
+      "formData": "Upload the KoboToolbox answers workbook (e.g. \"…DonneesK.xlsx\"). Rows are appended to the layer's resources."
     },
     "kind": {
       "externalData": "External data",
       "formData": "Form data"
-    },
-    "resourceHint": {
-      "csv": "Optional. If left empty, the resource name is inferred from the CSV file name.",
-      "excel": "Resource names will be inferred from the sheet names. Make sure your sheet names are correct before uploading."
     },
     "success": "Data added successfully.",
     "title": "Add data"

--- a/webapp/src/shared/i18n/translations/en/common.json
+++ b/webapp/src/shared/i18n/translations/en/common.json
@@ -1,4 +1,40 @@
 {
+  "addData": {
+    "button": {
+      "pending": "Uploading...",
+      "submit": "Add data"
+    },
+    "description": "Upload a file to add data to a map layer.",
+    "error": {
+      "generic": "Upload failed. Please try again.",
+      "missingFile": "Please choose a file to upload.",
+      "missingForm": "Please select a layer to update."
+    },
+    "field": {
+      "file": "File to upload",
+      "form": "Layer / Form to update",
+      "formPlaceholder": "Select a layer",
+      "kind": "Kind of resource",
+      "resource": "Resource name (optional)",
+      "resourcePlaceholder": "Leave empty to infer from file name"
+    },
+    "forms": {
+      "enquete": "Household survey",
+      "inventaire_bio": "Biological inventory",
+      "inventaire_for": "Forest inventory",
+      "seed": "Reforestation"
+    },
+    "kind": {
+      "externalData": "External data",
+      "formData": "Form data"
+    },
+    "resourceHint": {
+      "csv": "Optional. If left empty, the resource name is inferred from the CSV file name.",
+      "excel": "Resource names will be inferred from the sheet names. Make sure your sheet names are correct before uploading."
+    },
+    "success": "Data added successfully.",
+    "title": "Add data"
+  },
   "auth": {
     "loginForm": {
       "button": {
@@ -36,6 +72,7 @@
       "system": "System"
     },
     "menu": {
+      "addData": "Add data",
       "goToAdmin": "Admin",
       "language": "Language",
       "login": "Login",

--- a/webapp/src/shared/i18n/translations/en/common.json
+++ b/webapp/src/shared/i18n/translations/en/common.json
@@ -4,26 +4,27 @@
       "pending": "Uploading...",
       "submit": "Add data"
     },
-    "description": "Upload a file to add data to a map layer.",
+    "description": "Upload a file to add data to the map.",
     "error": {
       "generic": "Upload failed. Please try again.",
       "missingFile": "Please choose a file to upload.",
-      "missingForm": "Please select a layer to update."
+      "missingForm": "Please select a data source to update."
     },
     "field": {
       "file": "File to upload",
-      "form": "Layer / Form to update",
-      "formPlaceholder": "Select a layer",
+      "form": "Data source to update",
+      "formPlaceholder": "Select a data source",
       "kind": "Kind of resource"
     },
     "hint": {
       "externalData": "The file name must match the target resource (e.g. \"for_dw.csv\"); Excel sheets are matched by sheet name.",
-      "formData": "Upload the KoboToolbox answers workbook (e.g. \"…DonneesK.xlsx\"). Rows are appended to the layer's resources."
+      "formData": "Upload the KoboToolbox answers workbook (e.g. \"…DonneesK.xlsx\"). Rows are appended to the data source."
     },
     "kind": {
       "externalData": "External data",
       "formData": "Form data"
     },
+    "refreshData": "Reload",
     "success": "Data added successfully.",
     "title": "Add data"
   },

--- a/webapp/src/shared/i18n/translations/fr/common.json
+++ b/webapp/src/shared/i18n/translations/fr/common.json
@@ -18,12 +18,6 @@
       "resource": "Nom de la ressource (facultatif)",
       "resourcePlaceholder": "Laissez vide pour déduire du nom du fichier"
     },
-    "forms": {
-      "enquete": "Enquête ménage",
-      "inventaire_bio": "Inventaire biologique",
-      "inventaire_for": "Inventaire forestier",
-      "seed": "Reboisement"
-    },
     "kind": {
       "externalData": "Données externes",
       "formData": "Données de formulaire"

--- a/webapp/src/shared/i18n/translations/fr/common.json
+++ b/webapp/src/shared/i18n/translations/fr/common.json
@@ -14,17 +14,15 @@
       "file": "Fichier à importer",
       "form": "Couche / Formulaire à mettre à jour",
       "formPlaceholder": "Sélectionnez une couche",
-      "kind": "Type de ressource",
-      "resource": "Nom de la ressource (facultatif)",
-      "resourcePlaceholder": "Laissez vide pour déduire du nom du fichier"
+      "kind": "Type de ressource"
+    },
+    "hint": {
+      "externalData": "Le nom du fichier doit correspondre à la ressource cible (ex. « for_dw.csv ») ; les feuilles Excel sont associées par nom de feuille.",
+      "formData": "Importez le classeur de réponses KoboToolbox (ex. « …DonneesK.xlsx »). Les lignes sont ajoutées aux ressources de la couche."
     },
     "kind": {
       "externalData": "Données externes",
       "formData": "Données de formulaire"
-    },
-    "resourceHint": {
-      "csv": "Facultatif. Si laissé vide, le nom de la ressource sera déduit du nom du fichier CSV.",
-      "excel": "Les noms des ressources seront déduits des noms des feuilles. Vérifiez les noms des feuilles avant l'import."
     },
     "success": "Données ajoutées avec succès.",
     "title": "Ajouter des données"

--- a/webapp/src/shared/i18n/translations/fr/common.json
+++ b/webapp/src/shared/i18n/translations/fr/common.json
@@ -4,26 +4,27 @@
       "pending": "Envoi en cours...",
       "submit": "Ajouter les données"
     },
-    "description": "Importez un fichier pour ajouter des données à une couche de la carte.",
+    "description": "Importez un fichier pour ajouter des données à la carte.",
     "error": {
       "generic": "Échec de l'import. Veuillez réessayer.",
       "missingFile": "Veuillez choisir un fichier à importer.",
-      "missingForm": "Veuillez sélectionner une couche à mettre à jour."
+      "missingForm": "Veuillez sélectionner une source de données à mettre à jour."
     },
     "field": {
       "file": "Fichier à importer",
-      "form": "Couche / Formulaire à mettre à jour",
-      "formPlaceholder": "Sélectionnez une couche",
+      "form": "Source de données à mettre à jour",
+      "formPlaceholder": "Sélectionnez une source de données",
       "kind": "Type de ressource"
     },
     "hint": {
       "externalData": "Le nom du fichier doit correspondre à la ressource cible (ex. « for_dw.csv ») ; les feuilles Excel sont associées par nom de feuille.",
-      "formData": "Importez le classeur de réponses KoboToolbox (ex. « …DonneesK.xlsx »). Les lignes sont ajoutées aux ressources de la couche."
+      "formData": "Importez le classeur de réponses KoboToolbox (ex. « …DonneesK.xlsx »). Les lignes sont ajoutées à la source de données."
     },
     "kind": {
       "externalData": "Données externes",
       "formData": "Données de formulaire"
     },
+    "refreshData": "Rafraichir",
     "success": "Données ajoutées avec succès.",
     "title": "Ajouter des données"
   },

--- a/webapp/src/shared/i18n/translations/fr/common.json
+++ b/webapp/src/shared/i18n/translations/fr/common.json
@@ -1,4 +1,40 @@
 {
+  "addData": {
+    "button": {
+      "pending": "Envoi en cours...",
+      "submit": "Ajouter les données"
+    },
+    "description": "Importez un fichier pour ajouter des données à une couche de la carte.",
+    "error": {
+      "generic": "Échec de l'import. Veuillez réessayer.",
+      "missingFile": "Veuillez choisir un fichier à importer.",
+      "missingForm": "Veuillez sélectionner une couche à mettre à jour."
+    },
+    "field": {
+      "file": "Fichier à importer",
+      "form": "Couche / Formulaire à mettre à jour",
+      "formPlaceholder": "Sélectionnez une couche",
+      "kind": "Type de ressource",
+      "resource": "Nom de la ressource (facultatif)",
+      "resourcePlaceholder": "Laissez vide pour déduire du nom du fichier"
+    },
+    "forms": {
+      "enquete": "Enquête ménage",
+      "inventaire_bio": "Inventaire biologique",
+      "inventaire_for": "Inventaire forestier",
+      "seed": "Reboisement"
+    },
+    "kind": {
+      "externalData": "Données externes",
+      "formData": "Données de formulaire"
+    },
+    "resourceHint": {
+      "csv": "Facultatif. Si laissé vide, le nom de la ressource sera déduit du nom du fichier CSV.",
+      "excel": "Les noms des ressources seront déduits des noms des feuilles. Vérifiez les noms des feuilles avant l'import."
+    },
+    "success": "Données ajoutées avec succès.",
+    "title": "Ajouter des données"
+  },
   "auth": {
     "loginForm": {
       "button": {
@@ -36,6 +72,7 @@
       "system": "Système"
     },
     "menu": {
+      "addData": "Ajouter des données",
       "goToAdmin": "Espace Admin",
       "language": "Langue",
       "login": "Connexion",

--- a/webapp/src/shared/ui/alert.tsx
+++ b/webapp/src/shared/ui/alert.tsx
@@ -18,6 +18,8 @@ const alertVariants = cva(
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
         info: "bg-info text-info-foreground  [&>svg]:text-info-foreground",
+        success:
+          "bg-success text-success-foreground [&>svg]:text-success-foreground",
       },
     },
   },

--- a/webapp/src/shared/ui/dialog.tsx
+++ b/webapp/src/shared/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/webapp/src/widgets/header/index.tsx
+++ b/webapp/src/widgets/header/index.tsx
@@ -5,14 +5,18 @@ import { useTranslation } from "@shared/i18n";
 import { Button } from "@shared/ui/button";
 import { URLS, useAbsoluteUrls } from "@shared/urls";
 
-import { UserMenu } from "./user-menu";
+import { UserMenu, type UserMenuProps } from "./user-menu";
 
 export type HeaderProps = {
   logoSrc: string;
   hasDashboard?: boolean;
-};
+} & UserMenuProps;
 
-export const Header: FC<HeaderProps> = ({ logoSrc, hasDashboard }) => {
+export const Header: FC<HeaderProps> = ({
+  logoSrc,
+  hasDashboard,
+  layerOptions,
+}) => {
   const navigate = useNavigate();
   const location = useLocation();
   const isDashboardPage =
@@ -47,7 +51,7 @@ export const Header: FC<HeaderProps> = ({ logoSrc, hasDashboard }) => {
                   : t("header.navigationButton.toDashboard")}
               </Button>
             )}
-            <UserMenu />
+            <UserMenu layerOptions={layerOptions} />
           </div>
         </div>
       </div>

--- a/webapp/src/widgets/header/user-menu.tsx
+++ b/webapp/src/widgets/header/user-menu.tsx
@@ -9,7 +9,7 @@ import type { FC } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { AddDataDialog } from "@features/add-data";
+import { AddDataDialog, type LayerOptions } from "@features/add-data";
 import { useCreateAdminSession } from "@features/admin/use-create-admin-session";
 import { useAuth } from "@features/auth";
 
@@ -28,7 +28,11 @@ import {
 import { LanguageSelector } from "./language-selector";
 import { ModeToggle } from "./mode-toggle";
 
-export const UserMenu: FC = () => {
+export type UserMenuProps = {
+  layerOptions?: LayerOptions;
+};
+
+export const UserMenu: FC<UserMenuProps> = ({ layerOptions }) => {
   const { t } = useTranslation("common");
 
   const navigate = useNavigate();
@@ -115,8 +119,9 @@ export const UserMenu: FC = () => {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {isAuthenticated && (
+      {isAuthenticated && layerOptions?.length && (
         <AddDataDialog
+          layerOptions={layerOptions}
           onOpenChange={setIsAddDataOpen}
           open={isAddDataOpen}
         />

--- a/webapp/src/widgets/header/user-menu.tsx
+++ b/webapp/src/widgets/header/user-menu.tsx
@@ -1,7 +1,15 @@
-import { DatabaseIcon, LogOutIcon, SettingsIcon, UserIcon } from "lucide-react";
+import {
+  DatabaseIcon,
+  LogOutIcon,
+  MapPinPlusIcon,
+  SettingsIcon,
+  UserIcon,
+} from "lucide-react";
 import type { FC } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { AddDataDialog } from "@features/add-data";
 import { useCreateAdminSession } from "@features/admin/use-create-admin-session";
 import { useAuth } from "@features/auth";
 
@@ -27,73 +35,92 @@ export const UserMenu: FC = () => {
   const { isAuthenticated, logout, token } = useAuth();
   const { isLoading, createAdminSession } = useCreateAdminSession(token);
 
+  const [isAddDataOpen, setIsAddDataOpen] = useState(false);
+
   const absoluteUrls = useAbsoluteUrls();
 
   const onLogin = () => navigate(absoluteUrls.LOGIN);
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild={true}>
-        <Button
-          className="focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
-          size="icon"
-          variant="outline"
-        >
-          <SettingsIcon className="h-[1.2rem] w-[1.2rem]" />
-          <span className="sr-only">User menu</span>
-        </Button>
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent
-        align="end"
-        className="bg-background"
-      >
-        <LanguageSelector />
-
-        <ModeToggle />
-
-        <DropdownMenuSeparator />
-
-        {isAuthenticated ? (
-          <>
-            <DropdownMenuItem
-              className="gap-sm"
-              disabled={isLoading}
-              onClick={createAdminSession}
-            >
-              <SettingsIcon />
-              {t("header.menu.goToAdmin")}
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              className="gap-sm"
-              disabled={isLoading}
-              onClick={() => alert("Not implemented yet")}
-            >
-              <DatabaseIcon />
-              {t("header.menu.seeDatabase")}
-            </DropdownMenuItem>
-
-            <DropdownMenuSeparator />
-
-            <DropdownMenuItem
-              className="gap-sm"
-              onClick={logout}
-            >
-              <LogOutIcon />
-              {t("header.menu.logout")}
-            </DropdownMenuItem>
-          </>
-        ) : (
-          <DropdownMenuItem
-            className="gap-sm"
-            onClick={onLogin}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild={true}>
+          <Button
+            className="focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+            size="icon"
+            variant="outline"
           >
-            <UserIcon />
-            {t("header.menu.login")}
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <SettingsIcon className="h-[1.2rem] w-[1.2rem]" />
+            <span className="sr-only">User menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align="end"
+          className="bg-background"
+        >
+          <LanguageSelector />
+
+          <ModeToggle />
+
+          <DropdownMenuSeparator />
+
+          {isAuthenticated ? (
+            <>
+              <DropdownMenuItem
+                className="gap-2"
+                onClick={() => setIsAddDataOpen(true)}
+              >
+                <MapPinPlusIcon />
+                {t("header.menu.addData")}
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={isLoading}
+                onClick={createAdminSession}
+              >
+                <SettingsIcon />
+                {t("header.menu.goToAdmin")}
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={isLoading}
+                onClick={() => alert("Not implemented yet")}
+              >
+                <DatabaseIcon />
+                {t("header.menu.seeDatabase")}
+              </DropdownMenuItem>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuItem
+                className="gap-2"
+                onClick={logout}
+              >
+                <LogOutIcon />
+                {t("header.menu.logout")}
+              </DropdownMenuItem>
+            </>
+          ) : (
+            <DropdownMenuItem
+              className="gap-2"
+              onClick={onLogin}
+            >
+              <UserIcon />
+              {t("header.menu.login")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {isAuthenticated && (
+        <AddDataDialog
+          onOpenChange={setIsAddDataOpen}
+          open={isAddDataOpen}
+        />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Highlights

1. Add "add-data" feature slice.
2. Add Dialog from shadcn CLI
3. I had an issue with some container breakpoints used by shadcn (max-w-lg) => the dialog sized was wronged. Why ? because of the spacing custom tokens added in the style. I removed it (and their usage) to be sure we don't have conflicts with native containers token. 

## Demos


### UI only


https://github.com/user-attachments/assets/5c631531-0966-404b-8f0f-5b2d924c2b4f



### Full flow - Form based (internal)

https://github.com/user-attachments/assets/0fbdeb6b-0871-4bde-96cf-af5c928e25a0


### Full flow - External data


https://github.com/user-attachments/assets/2708b958-3c88-46db-8d34-b9e786b4e2f0

