### PR TITLE
refactor(suspense): Extract in reusable API the suspense logic with cache

### DIFF
--- a/webapp/src/features/fallback/error-boundary-fallback.tsx
+++ b/webapp/src/features/fallback/error-boundary-fallback.tsx
@@ -1,59 +1,56 @@
-import type { TFunction } from "i18next";
 import { TriangleAlert } from "lucide-react";
 import { type FallbackProps, getErrorMessage } from "react-error-boundary";
 
 import { ICON_SIZE_HEADER } from "@features/indicators/components/constants";
 
+import { useTranslation } from "@shared/i18n";
 import type { APIError } from "@shared/lib/types";
 import { cn } from "@shared/lib/utils";
 import { Alert, AlertTitle } from "@shared/ui/alert";
 
 import { Button } from "@ui/button";
 
-// t must be passed to the fallback render function because the error boundary fallback component cannot call hooks like useTranslation
-// See https://react.dev/warnings/invalid-hook-call-warning
-// > 🔴 Do not call Hooks in class components.
-// while ErrorBoundary is a class component: https://github.com/bvaughn/react-error-boundary/blob/main/lib/components/ErrorBoundary.tsx#L45
-export function getFallbackRender({
-  retry,
-  t,
-}: {
+// `retry` is injected on top of the props react-error-boundary provides.
+export type ErrorBoundaryFallbackProps = FallbackProps & {
   retry?: () => void;
-  t: TFunction<"common", undefined>;
-}) {
-  function FallbackRender({ error }: FallbackProps) {
-    const apiError = error as APIError;
-    const errorMessage =
-      apiError.status === 401
-        ? t("error.pleaseLogin")
-        : (getErrorMessage(error) ?? t("error.unknownMessage"));
-    return (
-      <>
-        <Alert
-          className="w-full rounded-t-md rounded-b-none border-none text-xl py-lg bg-rose-950"
-          variant="destructive"
-        >
-          <TriangleAlert size={ICON_SIZE_HEADER} />
-          <AlertTitle className={cn("text-foreground")}>
-            {t("error.title")}
-          </AlertTitle>
-        </Alert>
-        <div className="flex flex-col">
-          <div className="flex flex-col items-center gap-4 py-10">
-            <h2 className="text-2xl font-bold text-accent">{errorMessage}</h2>
-            {retry && (
-              <Button
-                onClick={retry}
-                type="button"
-              >
-                {t("error.retry")}
-              </Button>
-            )}
-          </div>
-        </div>
-      </>
-    );
-  }
+};
 
-  return FallbackRender;
+export function ErrorBoundaryFallback({
+  error,
+  retry,
+}: ErrorBoundaryFallbackProps) {
+  const { t } = useTranslation("common");
+
+  const apiError = error as APIError;
+  const errorMessage =
+    apiError.status === 401
+      ? t("error.pleaseLogin")
+      : (getErrorMessage(error) ?? t("error.unknownMessage"));
+
+  return (
+    <>
+      <Alert
+        className="w-full rounded-t-md rounded-b-none border-none text-xl py-lg bg-rose-950"
+        variant="destructive"
+      >
+        <TriangleAlert size={ICON_SIZE_HEADER} />
+        <AlertTitle className={cn("text-foreground")}>
+          {t("error.title")}
+        </AlertTitle>
+      </Alert>
+      <div className="flex flex-col">
+        <div className="flex flex-col items-center gap-4 py-10">
+          <h2 className="text-2xl font-bold text-accent">{errorMessage}</h2>
+          {retry && (
+            <Button
+              onClick={retry}
+              type="button"
+            >
+              {t("error.retry")}
+            </Button>
+          )}
+        </div>
+      </div>
+    </>
+  );
 }

--- a/webapp/src/features/fallback/suspense-boundary.tsx
+++ b/webapp/src/features/fallback/suspense-boundary.tsx
@@ -1,0 +1,58 @@
+import { type ComponentProps, type ReactNode, Suspense, useMemo } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+
+import { ErrorBoundaryFallback } from "@features/fallback/error-boundary-fallback";
+import Loading from "@features/fallback/loading";
+
+type SuspenseBoundaryProps = {
+  /**
+   * The cached promise being read below (e.g. from `useSuspenseData`). Passed
+   * to `resetKeys` so the boundary resets whenever a fresh promise arrives —
+   * for instance after `retry` — letting the new attempt render.
+   */
+  resource: unknown;
+  /** Wired to the fallback's Retry button; usually `retry` from useSuspenseData. */
+  retry?: () => void;
+  /** Optional error logging, forwarded to <ErrorBoundary>. */
+  onError?: ComponentProps<typeof ErrorBoundary>["onError"];
+  children: ReactNode;
+};
+
+/**
+ * Standard `<ErrorBoundary>` + `<Suspense>` wrapper for our `use()` +
+ * cached-promise data fetching:
+ *  - `<Suspense>` shows <Loading /> while the promise is pending.
+ *  - `<ErrorBoundary>` shows the translated {@link ErrorBoundaryFallback} when
+ *    it rejects, with a Retry button wired to `retry`.
+ */
+export function SuspenseBoundary({
+  resource,
+  retry,
+  onError,
+  children,
+}: SuspenseBoundaryProps) {
+  // Memoised so the fallback component keeps a stable identity across renders
+  // (it only changes when `retry` does), avoiding needless remounts.
+  const FallbackComponent = useMemo(
+    () =>
+      function Fallback(props: FallbackProps) {
+        return (
+          <ErrorBoundaryFallback
+            {...props}
+            retry={retry}
+          />
+        );
+      },
+    [retry],
+  );
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={FallbackComponent}
+      onError={onError}
+      resetKeys={[resource]}
+    >
+      <Suspense fallback={<Loading />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/webapp/src/features/popup/components/popup.tsx
+++ b/webapp/src/features/popup/components/popup.tsx
@@ -1,9 +1,8 @@
-import { type FC, Suspense, useCallback, useMemo, useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { useTranslation } from "react-i18next";
+import type { FC } from "react";
 
-import { getFallbackRender } from "@features/fallback/error-boundary-fallback";
-import Loading from "@features/fallback/loading";
+import { SuspenseBoundary } from "@features/fallback/suspense-boundary";
+
+import { useSuspenseData } from "@shared/api/suspense-fetch";
 
 import type { RenderPopupProps } from "../renderPopup";
 
@@ -20,64 +19,21 @@ export const Popup: FC<PopupProps> = ({
   PopupContent,
   childrenProps,
 }) => {
-  const { t } = useTranslation("common");
-
-  // Retrieve external data before rendering popup
-  const [reloadKey, setReloadKey] = useState(0);
-  const externalDataPromise = useMemo(
-    () =>
-      fetchData({
-        force: reloadKey > 0,
-        promiseFunc,
-      }),
-    [reloadKey, promiseFunc],
-  );
-
-  const retry = useCallback(() => {
-    setReloadKey((k) => k + 1);
-  }, []);
-  const fallbackRender = useMemo(
-    () => getFallbackRender({ retry, t }),
-    [retry, t],
-  );
+  const { dataPromise: externalDataPromise, retry } = useSuspenseData({
+    fetcher: promiseFunc,
+  });
 
   return (
     <div className="h-(--popup-height) max-h-full">
-      <ErrorBoundary
-        fallbackRender={fallbackRender}
-        resetKeys={[externalDataPromise]}
+      <SuspenseBoundary
+        resource={externalDataPromise}
+        retry={retry}
       >
-        <Suspense fallback={<Loading />}>
-          <PopupContent
-            {...childrenProps}
-            externalDataPromise={externalDataPromise}
-          />
-        </Suspense>
-      </ErrorBoundary>
+        <PopupContent
+          {...childrenProps}
+          externalDataPromise={externalDataPromise}
+        />
+      </SuspenseBoundary>
     </div>
   );
 };
-
-const cache = new WeakMap<PromiseFunc, Promise<any>>();
-
-function fetchData({
-  promiseFunc,
-  force,
-}: {
-  promiseFunc: () => Promise<any>;
-  force?: boolean;
-}): Promise<any> {
-  const cachedPromise = cache.get(promiseFunc);
-
-  if (cachedPromise && !force) {
-    return cachedPromise;
-  }
-  const promise = promiseFunc().catch((err) => {
-    // Don't cache failures forever; allow retries (e.g. after navigation / remount).
-    cache.delete(promiseFunc);
-    throw err;
-  });
-  cache.set(promiseFunc, promise);
-
-  return promise;
-}

--- a/webapp/src/shared/api/suspense-fetch.ts
+++ b/webapp/src/shared/api/suspense-fetch.ts
@@ -1,0 +1,117 @@
+import { useCallback, useMemo, useState } from "react";
+
+/**
+ * Fetch data for React's `use()` + `<Suspense>`.
+ *
+ * `use(promise)` suspends until the promise settles, but it re-reads whatever
+ * promise it is given on EVERY render. If a component created a brand-new
+ * promise each render, it would suspend forever on a promise it never keeps.
+ * So the promise handed to `use()` must be *stable* across renders — the same
+ * instance until we explicitly decide to refetch.
+ * See https://react.dev/reference/react/use#caching-promises-for-client-components
+ *
+ * This module memoises promises in a cache so the identical promise instance is
+ * returned until a forced refetch replaces it.
+ *
+ * Typical usage:
+ *
+ * ```tsx
+ * const { getDashboardData } = useApi();
+ * const fetcher = useCallback(
+ *   () => getDashboardData(LAYERS.INVENTARY),
+ *   [getDashboardData],
+ * );
+ * const { dataPromise, retry } = useSuspenseData({ fetcher });
+ *
+ * return (
+ *   <SuspenseBoundary resource={dataPromise} retry={retry}>
+ *     <ChildThatCallsUse dataPromise={dataPromise} />
+ *   </SuspenseBoundary>
+ * );
+ * ```
+ */
+
+// A no-argument function that starts a request. The fetcher's *identity* is the
+// cache key: in this app fetchers come from `createApiClient(authToken)`, so a
+// new auth token produces a new fetcher, which lands in a fresh cache bucket —
+// stale (e.g. logged-out) data can never leak across sessions. A WeakMap lets
+// buckets for gone-away fetchers be garbage-collected automatically.
+type Fetcher<T> = () => Promise<T>;
+
+// Sub-key used when a caller does not need several promises per fetcher.
+const DEFAULT_KEY = "__default__";
+
+const cache = new WeakMap<Fetcher<unknown>, Map<string, Promise<unknown>>>();
+
+function getBucket<T>(fetcher: Fetcher<T>): Map<string, Promise<T>> {
+  let bucket = cache.get(fetcher);
+  if (!bucket) {
+    bucket = new Map<string, Promise<T>>();
+    cache.set(fetcher, bucket);
+  }
+  return bucket as Map<string, Promise<T>>;
+}
+
+/**
+ * Return a cached promise for `fetcher`, creating and caching it on first call.
+ *
+ * - `key`: keep several promises alive for the same fetcher (e.g. one per
+ *   layer). Omit it when a fetcher only ever produces one promise.
+ * - `force`: skip the cache and replace the stored promise with a fresh fetch.
+ *
+ * Rejected promises are never cached: a failed request is dropped so the next
+ * attempt (retry / remount) starts clean instead of replaying the old error.
+ */
+export function getCachedPromise<T>({
+  fetcher,
+  key = DEFAULT_KEY,
+  force = false,
+}: {
+  fetcher: Fetcher<T>;
+  key?: string;
+  force?: boolean;
+}): Promise<T> {
+  const bucket = getBucket(fetcher);
+  const cached = bucket.get(key);
+
+  if (cached && !force) {
+    return cached;
+  }
+
+  const promise = fetcher().catch((error) => {
+    bucket.delete(key);
+    throw error;
+  });
+  bucket.set(key, promise);
+
+  return promise;
+}
+
+/**
+ * Hand a parent component a stable, cached promise to pass down to a
+ * `use()`-powered child, plus a `retry` that forces a fresh fetch.
+ *
+ * `fetcher` must be stable across renders (wrap it in `useCallback`) — its
+ * identity scopes the cache. Pair the returned `dataPromise` and `retry` with
+ * `<SuspenseBoundary>`.
+ */
+export function useSuspenseData<T>({
+  fetcher,
+  key,
+}: {
+  fetcher: Fetcher<T>;
+  key?: string;
+}): { dataPromise: Promise<T>; retry: () => void } {
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const dataPromise = useMemo(
+    // reloadKey === 0 on first render reuses any cached promise; each retry
+    // bumps it, which both forces a refetch and re-runs this memo.
+    () => getCachedPromise({ fetcher, force: reloadKey > 0, key }),
+    [fetcher, key, reloadKey],
+  );
+
+  const retry = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  return { dataPromise, retry };
+}

--- a/webapp/src/widgets/dashboard/dashboard.tsx
+++ b/webapp/src/widgets/dashboard/dashboard.tsx
@@ -1,97 +1,34 @@
-import { Suspense, useCallback, useMemo, useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { useCallback } from "react";
 
-import LoadedDashboard, {
-  type DashboardData,
-} from "@widgets/dashboard/loaded-dashboard";
+import LoadedDashboard from "@widgets/dashboard/loaded-dashboard";
 
-import { getFallbackRender } from "@features/fallback/error-boundary-fallback";
-import Loading from "@features/fallback/loading";
+import { SuspenseBoundary } from "@features/fallback/suspense-boundary";
 
 import { LAYERS } from "@shared/api/layers";
+import { useSuspenseData } from "@shared/api/suspense-fetch";
 import { useApi } from "@shared/hooks/useApi";
-import { useTranslation } from "@shared/i18n";
-
-type GetDashboardData = (layer: string) => Promise<DashboardData>;
-type Layer = (typeof LAYERS)[keyof typeof LAYERS];
-
-// ✅ Cache Promises so the same one is reused across renders
-// required by 'use()', see https://react.dev/reference/react/use#caching-promises-for-client-components
-// Cache is scoped by API client (auth token) + layer to avoid leaking data across sessions.
-const cache = new WeakMap<
-  GetDashboardData,
-  Map<Layer, Promise<DashboardData>>
->();
-
-function getPerApiCache(getDashboardData: GetDashboardData) {
-  const perApiCache = cache.get(getDashboardData);
-  if (perApiCache) {
-    return perApiCache;
-  }
-  const newPerApiCache = new Map<Layer, Promise<DashboardData>>();
-  cache.set(getDashboardData, newPerApiCache);
-  return newPerApiCache;
-}
-
-function fetchData({
-  getDashboardData,
-  layer,
-  force,
-}: {
-  getDashboardData: GetDashboardData;
-  layer: Layer;
-  force?: boolean;
-}): Promise<DashboardData> {
-  const perLayerCache = getPerApiCache(getDashboardData);
-  const cachedPromise = perLayerCache.get(layer);
-
-  if (cachedPromise && !force) {
-    return cachedPromise;
-  }
-  const promise = getDashboardData(layer).catch((err) => {
-    // Don't cache failures forever; allow retries (e.g. after navigation / remount).
-    perLayerCache.delete(layer);
-    throw err;
-  });
-  perLayerCache.set(layer, promise);
-
-  return promise;
-}
 
 export default function Dashboard() {
-  const { t } = useTranslation("common");
   const { getDashboardData } = useApi();
-  const [reloadKey, setReloadKey] = useState(0);
-  const dataPromise = useMemo(
-    () =>
-      fetchData({
-        force: reloadKey > 0,
-        getDashboardData,
-        layer: LAYERS.INVENTARY,
-      }),
-    [getDashboardData, reloadKey],
-  );
 
-  const retry = useCallback(() => {
-    setReloadKey((k) => k + 1);
-  }, []);
-  const fallbackRender = useMemo(
-    () => getFallbackRender({ retry, t }),
-    [retry, t],
+  // Stable per API client (auth token) so the promise cache stays scoped to
+  // the current session — see suspense-fetch.ts.
+  const fetcher = useCallback(
+    () => getDashboardData(LAYERS.INVENTARY),
+    [getDashboardData],
   );
+  const { dataPromise, retry } = useSuspenseData({ fetcher });
 
   return (
-    <ErrorBoundary
-      fallbackRender={fallbackRender}
+    <SuspenseBoundary
       onError={(error, info) => {
         // Log the error to your error reporting service
         console.error("Error in Dashboard:", error, info);
       }}
-      resetKeys={[dataPromise]}
+      resource={dataPromise}
+      retry={retry}
     >
-      <Suspense fallback={<Loading />}>
-        <LoadedDashboard dataPromise={dataPromise} />
-      </Suspense>
-    </ErrorBoundary>
+      <LoadedDashboard dataPromise={dataPromise} />
+    </SuspenseBoundary>
   );
 }


### PR DESCRIPTION
## Goals

1. Transform the error boundary into a Functional Component (that can use translations inside now)
2. Extract the promise with key storage into a reusable API, to make any new usage of this `use` pattern easier and ready out of the box