### PR TITLE
fix(backend): use the same pandas version as coordo

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,6 @@ djangorestframework==3.16.0
 djangorestframework_simplejwt==5.5.1
 django-cors-headers==4.9.0
 docutils==0.22
-pandas==3.0
+pandas==3.0.3
 python-dotenv==1.2.2
 whitenoise[brotli]==6.12.0


### PR DESCRIPTION
Note that it's not enough to fix the broken CI (since https://github.com/dataforgoodfr/14_Data4Trees/commit/28fa0789bc1a194266624d4231be8cf4bb1d62e5). But I don't know the backend, so I'm not sure how to fix the next error.